### PR TITLE
Patient-cards renderer: Typeform-style intake with keyboard navigation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,55 @@
+# CONTEXT
+
+Glossary of domain terms used across this codebase. Definitions here are the canonical meaning; if a discussion uses a term differently, the disagreement is real and needs to be resolved against this file.
+
+Only terms meaningful to domain experts (clinicians, form authors, integrators) appear here. Implementation-level abstractions (class names, file paths, module structure) do not.
+
+## Form authoring
+
+**Form** — A YAML/JSON definition of an Electronic Health Record questionnaire. Composed of Sections, Groups, Subforms, and Fields. Authored once, rendered by any of the available renderers.
+
+**Section** — Top-level grouping within a Form. Has a title, an ordered list of children (Fields, Groups, Subforms), optional description and keywords.
+
+**Group** — A recursive container of Fields, nested Groups, and Subforms. Has a title, layout hints (`span`, `borderless`), and optional computed properties. Groups can nest arbitrarily within a Section or within another Group.
+
+**Subform** — A Form embedded inside another Form by reference. Allows reusing form fragments (e.g., a shared demographic block) across multiple Forms.
+
+**Field** — A leaf question. Has a label, a type (Text, Number, Measure, Date, Time, DateTime, Dropdown, Radio, Checkbox, Token, ItemsList, Label, Button), optional validators, optional computed properties, and optional value schema (for Text fields).
+
+**Computed property** — A sandboxed expression on a Field/Group/Section that evaluates at render time against current form values. Common uses: `hidden`, `readonly`, `span`. Re-evaluated whenever dependent values change.
+
+**Validator** — `{ validation: string, message: string }` on a Field. The expression evaluates against form values; truthy means invalid; the message surfaces to the user. Multiple validators per Field are conjunctive.
+
+**Cross-card validator** — In patient-cards rendering only: a validator whose expression depends on Fields that appear on a later card than the validator's own Field. Cannot be evaluated until those later cards are answered; deferred to the review card.
+
+## Rendering
+
+**Renderer** — A strategy for translating a Form into Lit templates. The `<icure-form>` element dispatches to one renderer per render pass, selected by its `renderer` prop. Today: `form` (clinician-dense layout) and `patient-cards` (patient-friendly card sequence).
+
+**Patient renderer** / **patient-cards renderer** — The renderer that presents a Form to a patient as a linear sequence of Typeform-style cards. Optimized for pre-visit intake.
+
+**Card** (patient-cards only) — A single screen presented to the patient. Contains at most `questionsPerCard` interactive Fields (default 1). Labels and read-only display Fields can additionally appear on the card but do not count toward the limit.
+
+**Auto-flatten** — The algorithm by which the patient renderer turns a Form's Section/Group/Subform/Field tree into a flat linear sequence of Cards. Walks the tree depth-first, skips elements hidden by `hiddenForPatient` or by computed `hidden`, recurses transparently into Subforms, and chunks interactive Fields into Cards of size ≤ `questionsPerCard`.
+
+**Welcome card** — The first card the patient sees. Shows the Form title and `description`. Patient presses Start to enter the question sequence. Not counted in progress.
+
+**Review card** — Penultimate card. Shows all answers grouped by Section, each with an edit-jump back to its source card. Surfaces any cross-card validation failures. Not counted in progress.
+
+**Confirmation card** — Final card, shown after submit. Renders a thank-you and any host-app-provided next-step content. Not counted in progress.
+
+**Auto fast-forward resume** — When a patient reopens a partially-filled Form, the patient renderer plays through the card sequence, auto-advancing past Cards whose Fields are all answered and validating, stopping at the first unanswered or invalid card (or at the review card if all are complete). No explicit "current card" persistence; position is derived from data.
+
+**Stay semantics** (back-edit) — When the patient goes back, edits a value, and presses Continue, downstream Cards keep their previously-entered values. Visibility/conditional re-evaluation happens; data preservation is unconditional.
+
+## Patient-facing schema
+
+**`hiddenForPatient`** — Cascading boolean flag on Section, Group, Subform, or Field. Default `false`. When `true`, the element and its entire subtree are excluded from the patient renderer. Has no effect on the clinician renderer.
+
+**`questionsPerCard`** — A patient-cards renderer prop (not a Form-model property). Controls how many interactive Fields fit on one Card. Default `1`. `2` allowed.
+
+## Patient intake deployment
+
+**Pre-visit intake** — The canonical patient-cards use case: the clinician shares a link with a patient before an appointment; the patient fills out a one-shot questionnaire; the clinician reviews the submission ahead of or during the visit. Distinct from longitudinal self-monitoring, post-visit summary, and full patient-as-DataOwner editing — none of which are supported by patient-cards.
+
+**Token-scoped bounded delegation** — The canonical (recommended but not enforced) authentication pattern for patient intake. The clinician's system generates a short-lived link containing a token; the token resolves to a `User` holding a `SecureDelegation` permitting write access to a single target `Contact` (the intake submission) for a bounded time window. Patient never authenticates beyond clicking the link; link expires after submit or after timeout. Renderer itself is agnostic to this mechanism.

--- a/app/demo-app.ts
+++ b/app/demo-app.ts
@@ -125,6 +125,7 @@ class DemoApp extends LitElement {
 	]
 
 	@state() private selectedForm: Form = this.samples[0].form
+	@state() private rendererMode: 'form:tab' | 'patient-cards' = 'form:tab'
 	static get styles() {
 		return css`
 			.container {
@@ -171,6 +172,35 @@ class DemoApp extends LitElement {
 				flex: 9;
 				padding: 10px;
 			}
+
+			.renderer-toggle {
+				display: flex;
+				gap: 4px;
+				padding: 8px;
+				border-bottom: 1px solid #d4dde6;
+			}
+
+			.renderer-toggle button {
+				flex: 1;
+				padding: 8px 10px;
+				font-size: 13px;
+				border: 1px solid #b9c5d2;
+				background: #ffffff;
+				color: #1a1a1a;
+				border-radius: 4px;
+				cursor: pointer;
+			}
+
+			.renderer-toggle button.active {
+				background: #1d4ed8;
+				color: #ffffff;
+				border-color: #1d4ed8;
+			}
+
+			.renderer-toggle button:focus-visible {
+				outline: 2px solid #1d4ed8;
+				outline-offset: 2px;
+			}
 		`
 	}
 
@@ -203,6 +233,19 @@ class DemoApp extends LitElement {
 		return html`
 			<div class="container">
 				<div class="master">
+					<div class="renderer-toggle" role="group" aria-label="Renderer mode">
+						<button type="button" class="${this.rendererMode === 'form:tab' ? 'active' : ''}" aria-pressed="${this.rendererMode === 'form:tab'}" @click="${() => (this.rendererMode = 'form:tab')}">
+							Clinician
+						</button>
+						<button
+							type="button"
+							class="${this.rendererMode === 'patient-cards' ? 'active' : ''}"
+							aria-pressed="${this.rendererMode === 'patient-cards'}"
+							@click="${() => (this.rendererMode = 'patient-cards')}"
+						>
+							Patient cards
+						</button>
+					</div>
 					<ul>
 						${this.samples.map((s) => {
 							return html`<li class="${s.form === this.selectedForm ? 'selected' : ''}" @click="${() => (this.selectedForm = s.form)}">${s.title}</li>`
@@ -212,7 +255,7 @@ class DemoApp extends LitElement {
 				<div class="detail">
 					${this.samples.map((s) => {
 						return html`<div style="${s.form === this.selectedForm ? '' : 'display: none;'}">
-							<decorated-form id="${s.form.id ?? s.form.form}" .form="${s.form}" renderer="form:tab"></decorated-form>
+							<decorated-form id="${s.form.id ?? s.form.form}" .form="${s.form}" renderer="${this.rendererMode}"></decorated-form>
 						</div>`
 					})}
 				</div>

--- a/app/samples/preventi.yaml
+++ b/app/samples/preventi.yaml
@@ -1,0 +1,5465 @@
+form: Preventi
+id: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+description: Preventi Questionnaire
+sections:
+  - section: section.Summary
+    fields:
+      - group: group.Patient_Data
+        span: 24
+        fields:
+          - field: DP1
+            shortLabel: field.DP1.label.Name
+            span: 12
+            type: text-field
+            readonly: true
+            computedProperties:
+              value: |
+                return [patient.firstName, patient.lastName].join(' ')
+          - field: DP2
+            shortLabel: field.DP2.label.Gender
+            span: 6
+            type: text-field
+            readonly: true
+            computedProperties:
+              value: |
+                return `${patient.birthSex === 'Male' ? 'Homme' : patient.birthSex === 'Female' ? 'Femme' : 'Autre'}`
+          - field: DP3
+            shortLabel: field.DP3.label.Date_of_Birth
+            span: 6
+            type: text-field
+            readonly: true
+            computedProperties:
+              value: |
+                return `${patient.dateOfBirth?.toString().replace(/(....)(..)(..)/, '$3/$2/$1')} (${ageText(patient.dateOfBirth)})`
+          - field: GI01
+            shortLabel: field.GI01.label.Weight_kg
+            span: 6
+            type: number-field
+          - field: GI02
+            shortLabel: field.GI02.label.Height_cm
+            span: 6
+            type: number-field
+          - field: GI03
+            shortLabel: field.GI03.label.BMI_kg_m2
+            span: 6
+            type: number-field
+            computedProperties:
+              value: |
+                const w = parseContent(GI01[0]?.content)
+                let h = parseContent(GI02[0]?.content)
+                if (!w || !h) { return undefined }
+                if (h > 3) { h = h / 100 } 
+                return { content: { '*': { type: 'number', value: w / (h * h) } }, codes: [] }
+          - field: GI04
+            shortLabel: field.GI04.label.Waist_circumference_cm
+            span: 6
+            type: number-field
+          - field: GI08
+            shortLabel: field.GI08.label.Blood_type
+            span: 4
+            type: text-field
+          - field: GI05
+            shortLabel: field.GI05.label.SBP_mmHg
+            span: 4
+            type: number-field
+          - field: GI06
+            shortLabel: field.GI06.label.DBP_mmHg
+            span: 4
+            type: number-field
+          - field: GI07
+            shortLabel: field.GI07.label.HR_bpm
+            span: 4
+            type: number-field
+          - field: GI10
+            shortLabel: field.GI10.label.HDL_mmol_l
+            span: 4
+            type: number-field
+          - field: GI11
+            shortLabel: field.GI11.label.CV_Score
+            span: 4
+            type: number-field
+            computedProperties:
+              value: |
+                const sbp = parseContent(GI05[0]?.content)
+                const hdl = parseContent(GI10[0]?.content)
+                const patAge = patient.dateOfBirth ? age(patient.dateOfBirth) : undefined
+                const sex = patient.birthSex ?? 'Male'
+                const smoking = !(hasOption(DEP01[0], '1') || Number(text(DEP11)?.replace(/.*?([0-9]+).*/,'$1')) > 10)
+                if (!hdl || !patAge || !sbp) { return undefined }
+                return cvScore2({age: patAge, sex: sex?.toLowerCase(), hdl, sbp, smoking})
+      - group: group.Medical_Summary
+        span: 24
+        fields:
+          - field: RM1
+            shortLabel: field.RM1.label.Chronic_treatments
+            span: 24
+            multiline: true
+            type: text-field
+            computedProperties:
+              defaultValue: |
+                const treatments = []
+                if (hasOption(CV02[0], '1')) treatments.push('Traitement cardiovasculaire')
+                if (hasOption(RS03[0], '1') || hasOption(RS03[0], '2') || hasOption(RS03[0], '3') || hasOption(RS03[0], '4')) treatments.push('Traitement respiratoire')
+                return treatments.length ? treatments.join('\n') : 'Aucun'
+          - field: RM2
+            shortLabel: field.RM2.label.Allergies
+            span: 24
+            multiline: true
+            type: text-field
+            computedProperties:
+              defaultValue: |
+                return Promise.all([
+                  translate(language, 'mistral', 'Allergies'),
+                  translate(language, 'mistral', 'Intolerances'),
+                ]).then(([allerg, intol]) => {
+                  const intolerances = [
+                    NH17,NH18,NH19,NH20,NH21,NH22,NH23,NH24,NH25,NH26, NH27
+                  ].flatMap((f) => f).map((s) => parseContent(s?.content)).filter((x) => x?.toString()?.trim()?.length)
+
+                  if (intolerances.length) {
+                    return intol + ': ' + intolerances.join(', ')
+                  }
+                })
+          - field: RM3
+            shortLabel: field.RM3.label.Medical_history
+            span: 24
+            multiline: true
+            type: text-field
+            computedProperties:
+              defaultValue: |
+                const sections = [
+                  [CV01, 'Cardiovasculaire'],
+                  [EN01, 'Métabolique/Endocrinien'],
+                  [RS02, 'Respiratoire'],
+                  [MQ01, 'Musculo-squelettique'],
+                  [NE01, 'Neurologique'],
+                  [DG01, 'Digestif/Hépatique'],
+                  [UR01, 'Urinaire'],
+                ]
+                const results = sections
+                  .filter(([field]) => field[0]?.codes?.length > 0)
+                  .map(([field, label]) => {
+                    const selected = field.flatMap((f) => f?.codes ?? []).map((c) => c?.id).filter((x) => !!x)
+                    return selected.length ? Promise.all(selected.map((id) => translate(language, 'codex', id))).then((t) => label + ': ' + t.join(', ')) : null
+                  })
+                  .filter((x) => !!x)
+                const cancer = hasOption(CA01[0], '1') ? Promise.all(CA02.flatMap((f) => f?.codes ?? []).map((c) => c?.id).filter((x) => !!x).map((id) => translate(language, 'codex', id))).then((t) => 'Cancer: ' + t.join(', ')) : null
+                if (cancer) results.push(cancer)
+                const other = parseContent(OT02[0]?.content)
+                if (other) results.push('Autre: ' + other)
+                return results.length ? Promise.all(results).then((r) => r.filter((x) => !!x).join('\n')) : 'Aucun'
+          - field: RM4
+            shortLabel: field.RM4.label.Surgical_history
+            span: 24
+            multiline: true
+            type: text-field
+            computedProperties:
+              defaultValue: |
+                if (!hasOption(OT06[0], '1')) return 'Aucun'
+                const detail = parseContent(OT07[0]?.content)
+                return detail ? detail : 'Oui (non précisé)'
+          - field: RM5
+            shortLabel: field.RM5.label.Family_history
+            span: 24
+            multiline: true
+            type: text-field
+            computedProperties:
+              defaultValue: |
+                const items = []
+                if (hasOption(FA01[0], '1')) items.push('Maladie cardiovasculaire précoce')
+                if (hasOption(FA02[0], '1')) items.push('Cancer (sein, ovaire, prostate, colorectal, pancréas)')
+                if (hasOption(FA03[0], '1')) items.push('Diabète de type 2')
+                return items.length ? items.join('\n') : 'Aucun'
+      - group: group.Recommendations
+        span: 24
+        fields:
+          - field: RE01
+            shortLabel: field.RE01.label.General_health_status
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                const bmi = parseContent(GI03[0]?.content)
+                const cardioRisk = parseContent(GI11[0]?.content)
+
+                const bmiIdx = bmi < 18.5 ? 'BMI|18' :
+                               bmi < 25 ? 'BMI|18-25' :
+                               bmi < 30 ? 'BMI|25-30' :
+                               bmi < 35 ? 'BMI|30-35' : 
+                               bmi < 40 ? 'BMI|35-40' : 'BMI|40'
+
+                const cardioRiskIdx = cardioRisk < 5 ? 'CardioRisk|0' :
+                                     cardioRisk < 7 ? 'CardioRisk|1' : 'CardioRisk|2'
+
+                return translate(language, 'report', 'GeneralState', text(GI01), text(GI02), bmi?.toFixed(2) ?? translate(language, 'report', 'unknown'), translate(language, 'report', bmiIdx), text(GI11), translate(language, 'report', cardioRiskIdx))
+          - field: RE02
+            shortLabel: field.RE02.label.Social_and_environmental_context
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                const negCount = [SO01, SO03, HE04, HE07, HE10, HE13, HE16]
+                  .filter((f) => f[0]?.codes?.[0]?.id?.match(/\|[3-6]\|/)).length
+                const status = negCount === 0 ? 'POINT FORT' : negCount <= 3 ? "POINT D'ATTENTION" : 'POINT DE VIGILANCE'
+                return summarize({ domain: 'social-context', status, questions: [
+                  ['SO01', SO01[0]?.codes?.[0]?.id],
+                  ['SO03', SO03[0]?.codes?.[0]?.id],
+                  ['HE01', HE01[0]?.codes?.[0]?.id],
+                  ['HE03', HE03[0]?.codes?.[0]?.id],
+                  ['HE04', HE04[0]?.codes?.[0]?.id],
+                  ['HE07', HE07[0]?.codes?.[0]?.id],
+                  ['HE09', HE09[0]?.codes?.[0]?.id],
+                  ['HE10', HE10[0]?.codes?.[0]?.id],
+                  ['HE13', HE13[0]?.codes?.[0]?.id],
+                  ['HE16', HE16[0]?.codes?.[0]?.id],
+                ] }).then(r => r?.text ? ({ content: { '*': { type: 'string', value: r.text } }, codes: r.score ? [{ id: `PREVENTI-SOCIAL-SCORE|${r.score}|1`}] : [] }) : undefined)
+          - field: RE03
+            shortLabel: field.RE03.label.Mental_health
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                const nSM12 = parseContent(SM12[0]?.content)
+                const nSM43 = parseContent(SM43[0]?.content)
+                const nSM56 = parseContent(SM56[0]?.content)
+                const mentalStatus = (nSM12 >= 27 || nSM43 >= 15 || nSM56 >= 15) ? 'POINT DE VIGILANCE'
+                  : (nSM12 < 14 && nSM43 < 5 && nSM56 < 5) ? 'POINT FORT' : "POINT D'ATTENTION"
+                return summarize({ domain: 'mental-health', status: mentalStatus, questions: [
+                  ['SM02', SM02[0]?.codes?.[0]?.id], ['SM03', SM03[0]?.codes?.[0]?.id],
+                  ['SM04', SM04[0]?.codes?.[0]?.id], ['SM05', SM05[0]?.codes?.[0]?.id],
+                  ['SM06', SM06[0]?.codes?.[0]?.id], ['SM07', SM07[0]?.codes?.[0]?.id],
+                  ['SM08', SM08[0]?.codes?.[0]?.id], ['SM09', SM09[0]?.codes?.[0]?.id],
+                  ['SM10', SM10[0]?.codes?.[0]?.id], ['SM11', SM11[0]?.codes?.[0]?.id],
+                  ['SM14', text(SM14)],
+                  ['SM36', SM36[0]?.codes?.[0]?.id], ['SM37', SM37[0]?.codes?.[0]?.id],
+                  ['SM38', SM38[0]?.codes?.[0]?.id], ['SM39', SM39[0]?.codes?.[0]?.id],
+                  ['SM40', SM40[0]?.codes?.[0]?.id], ['SM41', SM41[0]?.codes?.[0]?.id],
+                  ['SM42', SM42[0]?.codes?.[0]?.id],
+                  ['SM47', SM47[0]?.codes?.[0]?.id], ['SM48', SM48[0]?.codes?.[0]?.id],
+                  ['SM49', SM49[0]?.codes?.[0]?.id], ['SM50', SM50[0]?.codes?.[0]?.id],
+                  ['SM51', SM51[0]?.codes?.[0]?.id], ['SM52', SM52[0]?.codes?.[0]?.id],
+                  ['SM53', SM53[0]?.codes?.[0]?.id], ['SM54', SM54[0]?.codes?.[0]?.id],
+                  ['SM55', SM55[0]?.codes?.[0]?.id],
+                ] }).then(r => r?.text ? ({ content: { '*': { type: 'string', value: r.text } }, codes: r.score ? [{ id: `PREVENTI-MH-SCORE|${r.score}|1`}] : [] }) :  undefined)
+          - field: RE03B
+            shortLabel: field.RE03B.label.Sleep_quality
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                const sleepNeg = [CD02,CD03,CD04,CD05,CD06,CD07,CD08,CD09,CD10,CD11,CD12,CD13,CD14,CD15,CD16,CD17]
+                  .filter((f) => score(f[0]) >= 3).length
+                const sleepStatus = sleepNeg === 0 ? 'POINT FORT' : sleepNeg <= 4 ? "POINT D'ATTENTION" : 'POINT DE VIGILANCE'
+                return summarize({ domain: 'sleep', status: sleepStatus, questions: [
+                  ['CD02', CD02[0]?.codes?.[0]?.id], ['CD03', CD03[0]?.codes?.[0]?.id],
+                  ['CD04', CD04[0]?.codes?.[0]?.id], ['CD05', CD05[0]?.codes?.[0]?.id],
+                  ['CD06', CD06[0]?.codes?.[0]?.id], ['CD07', CD07[0]?.codes?.[0]?.id],
+                  ['CD08', CD08[0]?.codes?.[0]?.id], ['CD09', CD09[0]?.codes?.[0]?.id],
+                  ['CD10', CD10[0]?.codes?.[0]?.id], ['CD11', CD11[0]?.codes?.[0]?.id],
+                  ['CD12', CD12[0]?.codes?.[0]?.id], ['CD13', CD13[0]?.codes?.[0]?.id],
+                  ['CD14', CD14[0]?.codes?.[0]?.id], ['CD15', CD15[0]?.codes?.[0]?.id],
+                  ['CD16', CD16[0]?.codes?.[0]?.id], ['CD17', CD17[0]?.codes?.[0]?.id],
+                ] }).then(r => r?.text ? ({ content: { '*': { type: 'string', value: r.text } }, codes: r.score ? [{ id: `PREVENTI-SLEEP-SCORE|${r.score}|1`}] : [] }) : undefined)
+          - field: RE04
+            shortLabel: field.RE04.label.Physical_activity
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                const pa05Score = score(PA05[0])
+                const pa08Score = score(PA08[0])
+                const paStatus = (pa05Score >= 2 && pa08Score >= 2) ? 'POINT FORT'
+                  : (pa05Score === 0 || pa08Score === 0) ? 'POINT DE VIGILANCE' : "POINT D'ATTENTION"
+                return Promise.all([
+                  translate(language, 'mistral', 'PA09', text(PA09)),
+                  translate(language, 'mistral', 'PA12', text(PA12)),
+                ]).then(([pa09, pa12]) =>
+                  summarize({ domain: 'physical-activity', status: paStatus, questions: [
+                    ['PA05', PA05[0]?.codes?.[0]?.id],
+                    ['PA08', PA08[0]?.codes?.[0]?.id === 'PA08|1|1' ? pa09 : PA08[0]?.codes?.[0]?.id],
+                    ['PA10', PA10[0]?.codes?.[0]?.id],
+                    ['PA11', PA11[0]?.codes?.[0]?.id === 'PA11|1|1' ? pa12 : PA11[0]?.codes?.[0]?.id],
+                  ] }).then(r => r?.text ? ({ content: { '*': { type: 'string', value: r.text } }, codes: r.score ? [{ id: `PREVENTI-PA-SCORE|${r.score}|1`}] : [] }) : undefined))
+          - field: RE04B
+            shortLabel: field.RE04B.label.Nutrition
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                const nhNeg = [NH01,NH03,NH05,NH06,NH07,NH08,NH09]
+                  .filter((f) => f[0]?.codes?.[0]?.id?.match(/\|[4-5]\|/)).length
+                const nhStatus = nhNeg === 0 ? 'POINT FORT' : nhNeg <= 2 ? "POINT D'ATTENTION" : 'POINT DE VIGILANCE'
+                return Promise.all([
+                  translate(language, 'mistral', 'NH02', text(NH02)),
+                  translate(language, 'mistral', 'NH04', text(NH04)),
+                  translate(language, 'mistral', 'NH16', text(NH16)),
+                ]).then(([nh02, nh04, nh16]) =>
+                  summarize({ domain: 'nutrition', status: nhStatus, questions: [
+                    ['NH01', NH01[0]?.codes?.[0]?.id],
+                    ['NH02', nh02],
+                    ['NH03', NH03[0]?.codes?.[0]?.id],
+                    ['NH04', nh04],
+                    ['NH05', NH05[0]?.codes?.[0]?.id],
+                    ['NH06', NH06[0]?.codes?.[0]?.id],
+                    ['NH07', NH07[0]?.codes?.[0]?.id],
+                    ['NH08', NH08[0]?.codes?.[0]?.id],
+                    ['NH09', NH09[0]?.codes?.[0]?.id],
+                    ['NH16', nh16],
+                  ] }).then(r => r?.text ? ({ content: { '*': { type: 'string', value: r.text } }, codes: r.score ? [{ id: `PREVENTI-NH-SCORE|${r.score}|1`}] : [] }) : undefined))
+          - field: RE05
+            shortLabel: field.RE05.label.Alcohol_consumption_and
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                const smokes = hasOption(DEP01[0], '3')
+                const drinks = hasOption(DEP04[0], '1')
+                const neverSmoked = hasOption(DEP01[0], '1')
+                const neverDrank = hasOption(DEP04[0], '2')
+                const status = (neverSmoked && neverDrank) ? 'POINT FORT'
+                  : (smokes || drinks) ? 'POINT DE VIGILANCE' : "POINT D'ATTENTION"
+                return summarize({ domain: 'dependencies', status, questions: [
+                  ['DEP01', DEP01[0]?.codes?.[0]?.id],
+                  ['DEP11', text(DEP11)],
+                  ['DEP02', text(DEP02)],
+                  ['DEP03', text(DEP03)],
+                  ['DEP04', DEP04[0]?.codes?.[0]?.id],
+                  ['DEP12', text(DEP12)],
+                  ['DEP05', text(DEP05)],
+                  ['DEP06', text(DEP06)],
+                ] }).then(r => r?.text ? ({ content: { '*': { type: 'string', value: r.text } }, codes: r.score ? [{ id: `PREVENTI-DEP-SCORE|${r.score}|1`}] : [] }) : undefined)
+          - field: RE06
+            shortLabel: field.RE06.label.Quality_and_life_expectancy
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                return translate(language, 'health-journey', 'RE06')
+          - field: RE07
+            shortLabel: field.RE07.label.Health_journey
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                const sc32 = SC32[0]?.codes?.[0]?.id
+                const sc34 = SC34[0]?.codes?.[0]?.id
+                const sc37 = SC37[0]?.codes?.[0]?.id
+                const sc40 = SC40[0]?.codes?.[0]?.id
+                const dhdc01 = DHDC01[0]?.codes?.[0]?.id
+                const dhdc02 = DHDC02[0]?.codes?.[0]?.id
+                const dhdc04 = DHDC04[0]?.codes?.[0]?.id
+
+                return Promise.all([
+                  translate(language, 'health-journey', 'SC31'),
+                  translate(language, 'health-journey', 'SC32', translate(language, 'codex', sc32)),
+                  translate(language, 'health-journey', 'SC34', translate(language, 'codex', sc34)),
+                  translate(language, 'health-journey', 'SC36'),
+                  translate(language, 'health-journey', 'SC37', translate(language, 'codex', sc37)),
+                  translate(language, 'health-journey', 'SC39'),
+                  translate(language, 'health-journey', 'SC40', translate(language, 'codex', sc40)),
+                  translate(language, 'health-journey', 'SC70'),
+                  translate(language, 'health-journey', 'SC69'),
+                  translate(language, 'health-journey', 'SC68'),
+                  translate(language, 'health-journey', 'DHDC01', translate(language, 'codex', dhdc01)),
+                  translate(language, 'health-journey', 'DHDC02', translate(language, 'codex', dhdc02)),
+                  translate(language, 'health-journey', 'DHDC04|1-3', translate(language, 'codex', dhdc04)),
+                  translate(language, 'health-journey', 'DHDC04|4'),
+                  translate(language, 'health-journey', 'DHDC04|5'),
+                  translate(language, 'health-journey', 'GP03|1'),
+                  translate(language, 'health-journey', 'GP03|2'),
+                  translate(language, 'health-journey', 'GP05|1'),
+                  translate(language, 'health-journey', 'GP05|2'),
+                  translate(language, 'health-journey', 'GP05|3'),
+                  translate(language, 'health-journey', 'GP05|4'),
+                ]).then(([
+                  t_sc31,
+                  t_sc32,
+                  t_sc34,
+                  t_sc36,
+                  t_sc37,
+                  t_sc39,
+                  t_sc40,
+                  t_sc70,
+                  t_sc69,
+                  t_sc68,
+                  t_dhdc01,
+                  t_dhdc02,
+                  t_dhdc04_13,
+                  t_dhdc04_4,
+                  t_dhdc04_5,
+                  t_gp03_1,
+                  t_gp03_2,
+                  t_gp05_1,
+                  t_gp05_2,
+                  t_gp05_3,
+                  t_gp05_4,
+                ]) => {              
+                 return (hasOption(SC31[0], '2') ? t_sc31 + '\n' : '') +
+                                                      (sc32?.length > 0 ? t_sc32 + '\n' : '') +
+                                                      (sc34?.length > 0 ? t_sc34 + '\n' : '') +
+                                                      (hasOption(SC36[0], '2') ? t_sc36 + '\n' : '') +
+                                                      (sc37?.length > 0 ? t_sc37 + '\n' : '') +
+                                                      (hasOption(SC39[0], '2') ? t_sc39 + '\n' : '') +
+                                                      (sc40?.length > 0 ? t_sc40 + '\n' : '') +
+                                                      ((hasOption(DHDC01[0], '1') || hasOption(DHDC01[0], '2') || hasOption(DHDC01[0], '3') || hasOption(DHDC01[0], '4')) ? t_dhdc01 + '\n' : '') +
+                                                      (dhdc02?.length > 0 ? t_dhdc02 + '\n' : '') +
+                                                      ((hasOption(DHDC04[0], '1') || hasOption(DHDC04[0], '2') || hasOption(DHDC04[0], '3')) ? t_dhdc04_13 + '\n' : '') +
+                                                      (hasOption(DHDC04[0], '4') ? t_dhdc04_4 + '\n' : '') +
+                                                      (hasOption(DHDC04[0], '5') ? t_dhdc04_5 + '\n' : '') +
+                                                      (hasOption(GP03[0], '1') ? t_gp03_1 + '\n' : '') +
+                                                      (hasOption(GP03[0], '2') ? t_gp03_2 + '\n' : '') +
+                                                      (hasOption(GP05[0], '1') ? t_gp05_1 + '\n' : '') +
+                                                      (hasOption(GP05[0], '2') ? t_gp05_2 + '\n' : '') +
+                                                      (hasOption(GP05[0], '3') ? t_gp05_3 + '\n' : '') +
+                                                      (hasOption(GP05[0], '4') ? t_gp05_4 + '\n' : '')
+                })
+          - field: RE08
+            shortLabel: field.RE08.label.Blood_test_results
+            span: 24
+            type: text-field
+            multiline: true
+          - field: RE09
+            shortLabel: field.RE09.label.Conclusion._Key_recommendations
+            span: 24
+            type: text-field
+            multiline: true
+            computedProperties:
+              defaultValue: |
+                const re02Text = RE02[0]?.content?.['*']?.value ?? text(RE02)
+                const re03Text = RE03[0]?.content?.['*']?.value ?? text(RE03)
+                const re03bText = RE03B[0]?.content?.['*']?.value ?? text(RE03B)
+                const re04Text = RE04[0]?.content?.['*']?.value ?? text(RE04)
+                const re04bText = RE04B[0]?.content?.['*']?.value ?? text(RE04B)
+                const re05Text = RE05[0]?.content?.['*']?.value ?? text(RE05)
+                const re06Text = RE06[0]?.content?.['*']?.value ?? text(RE06)
+                const re07Text = RE07[0]?.content?.['*']?.value ?? text(RE07)
+
+                if (!re02Text || !re03Text || !re03bText || !re04Text || !re04bText || !re05Text || !re06Text || !re07Text) {
+                  return undefined
+                }
+
+                const socialNeg = [SO01, SO03, HE04, HE07, HE10, HE13, HE16]
+                  .filter((f) => f[0]?.codes?.[0]?.id?.match(/\|[3-6]\|/)).length
+                const socialStatus = socialNeg === 0 ? 'POINT FORT' : socialNeg <= 3 ? "POINT D'ATTENTION" : 'POINT DE VIGILANCE'
+
+                const nSM12 = parseContent(SM12[0]?.content)
+                const nSM43 = parseContent(SM43[0]?.content)
+                const nSM56 = parseContent(SM56[0]?.content)
+                const mentalStatus = (nSM12 >= 27 || nSM43 >= 15 || nSM56 >= 15) ? 'POINT DE VIGILANCE'
+                  : (nSM12 < 14 && nSM43 < 5 && nSM56 < 5) ? 'POINT FORT' : "POINT D'ATTENTION"
+
+                const sleepNeg = [CD02,CD03,CD04,CD05,CD06,CD07,CD08,CD09,CD10,CD11,CD12,CD13,CD14,CD15,CD16,CD17]
+                  .filter((f) => score(f[0]) >= 3).length
+                const sleepStatus = sleepNeg === 0 ? 'POINT FORT' : sleepNeg <= 4 ? "POINT D'ATTENTION" : 'POINT DE VIGILANCE'
+
+                const pa05Score = score(PA05[0])
+                const pa08Score = score(PA08[0])
+                const paStatus = (pa05Score >= 2 && pa08Score >= 2) ? 'POINT FORT'
+                  : (pa05Score === 0 || pa08Score === 0) ? 'POINT DE VIGILANCE' : "POINT D'ATTENTION"
+
+                const nhNeg = [NH01,NH03,NH05,NH06,NH07,NH08,NH09]
+                  .filter((f) => f[0]?.codes?.[0]?.id?.match(/\|[4-5]\|/)).length
+                const nhStatus = nhNeg === 0 ? 'POINT FORT' : nhNeg <= 2 ? "POINT D'ATTENTION" : 'POINT DE VIGILANCE'
+
+                const smokes = hasOption(DEP01[0], '3')
+                const drinks = hasOption(DEP04[0], '1')
+                const neverSmoked = hasOption(DEP01[0], '1')
+                const neverDrank = hasOption(DEP04[0], '2')
+                const depStatus = (neverSmoked && neverDrank) ? 'POINT FORT'
+                  : (smokes || drinks) ? 'POINT DE VIGILANCE' : "POINT D'ATTENTION"
+
+                const allStatuses = [socialStatus, mentalStatus, sleepStatus, paStatus, nhStatus, depStatus]
+                const hasVigilance = allStatuses.includes('POINT DE VIGILANCE')
+                const hasAttention = allStatuses.includes("POINT D'ATTENTION")
+                const globalStatus = hasVigilance ? 'ATTENTION_MEDICALE' : hasAttention ? 'EQUILIBRE_FRAGILE' : 'EQUILIBRE_SATISFAISANT'
+
+                const domainStatuses = {
+                  'social-context': socialStatus,
+                  'mental-health': mentalStatus,
+                  'sleep': sleepStatus,
+                  'physical-activity': paStatus,
+                  'nutrition': nhStatus,
+                  'dependencies': depStatus,
+                }
+
+                return summarize({ domain: 'conclusion', globalStatus, domainStatuses, questions: [
+                  ['RE02', re02Text],
+                  ['RE03', re03Text],
+                  ['RE03B', re03bText],
+                  ['RE04', re04Text],
+                  ['RE04B', re04bText],
+                  ['RE05', re05Text],
+                  ['RE06', re06Text],
+                  ['RE07', re07Text],
+                ] }).then(r => ({ content: { '*': { type: 'string', value: r.text } } }))
+  - section: section.General_Information
+    fields:
+      - field: GI01
+        shortLabel: field.GI01.label.Weight_kg_2
+        span: 24
+        type: number-field
+      - field: GI02
+        shortLabel: field.GI02.label.Height_cm_2
+        span: 24
+        type: number-field
+      - field: GI03-bis
+        shortLabel: field.GI03.label.BMI_kg_m2_2
+        span: 24
+        type: number-field
+        computedProperties:
+          value: |
+            const w = parseContent(GI01[0]?.content)
+            let h = parseContent(GI02[0]?.content)
+            if (!w || !h) { return undefined }
+            if (h > 3) { h = h / 100 } 
+            return { content: { '*': { type: 'number', value: w / (h * h) } }, codes: [] }
+      - field: GI04
+        shortLabel: field.GI04.label.Waist_circumference_cm_2
+        span: 24
+        type: number-field
+      - field: GI05
+        shortLabel: field.GI05.label.Blood_pressure_systolic_mmHg
+        span: 24
+        type: number-field
+      - field: GI06
+        shortLabel: field.GI06.label.Blood_pressure_diastolic_mmHg
+        span: 24
+        type: number-field
+      - field: GI07
+        shortLabel: field.GI07.label.Heart_rate_bpm
+        span: 24
+        type: number-field
+      - field: GI08
+        shortLabel: field.GI08.label.Blood_type_2
+        span: 24
+        type: text-field
+      - field: GI09
+        shortLabel: field.GI09.label.How_many_children_do_you_have
+        span: 24
+        type: text-field
+      - field: MS1
+        shortLabel: field.MS1.label.STD_screening
+        span: 24
+        type: text-field
+      - field: CP1
+        shortLabel: field.CP1.label.Patient_comment
+        span: 24
+        type: text-field
+  - section: section.Caregiver
+    fields:
+      - field: IC01
+        shortLabel: field.IC01.label.Do_you_at_least_once_a_week
+        span: 24
+        type: radio-button
+        options:
+          IC01|1|1: field.IC01.option.Yes
+          IC01|2|1: field.IC01.option.No
+      - field: IC02
+        shortLabel: field.IC02.label.Outside_your_profession_to_whom
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(IC01[0],'1')
+        options:
+          IC02|1|1: field.IC02.option.One_or_more_household_member_s
+          IC02|2|1: field.IC02.option.One_or_more_family_member_s_but
+          IC02|3|1: field.IC02.option.One_or_more_persons_not
+      - field: IC03
+        shortLabel: field.IC03.label.In_total_how_many_hours_per
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(IC01[0],'1')
+        options:
+          IC03|1|1: field.IC03.option.Less_than_10_hours_per_week
+          IC03|2|1: field.IC03.option.At_least_10_hours_but_less_than
+          IC03|3|1: field.IC03.option.20_hours_per_week_or_more
+  - section: section.Social_Life
+    fields:
+      - field: SO01
+        shortLabel: field.SO01.label.How_would_you_overall_describe
+        span: 24
+        type: radio-button
+        options:
+          SO01|1|1: field.SO01.option.Very_satisfying
+          SO01|2|1: field.SO01.option.Rather_satisfying
+          SO01|3|1: field.SO01.option.Rather_unsatisfying
+          SO01|4|1: field.SO01.option.Really_unsatisfying
+      - field: SO03
+        shortLabel: field.SO03.label.How_many_people_are_close
+        span: 24
+        type: radio-button
+        options:
+          SO03|1|1: field.SO03.option.None
+          SO03|2|1: field.SO03.option.1_or_2
+          SO03|3|1: field.SO03.option.3_to_5
+          SO03|4|1: field.SO03.option.6_or_more
+  - section: section.Environmental_Factors
+    fields:
+      - field: HE01
+        shortLabel: field.HE01.label.I_will_now_ask_you_2_sets_of
+        span: 24
+        type: label
+        standalone: true
+      - group: group.Series_1_Neighbourhood
+        span: 24
+        fields:
+          - field: HE03
+            shortLabel: field.HE03.label.In_your_neighbourhood_to_what
+            span: 24
+            type: label
+          - field: HE04
+            shortLabel: field.HE04.label.Is_traffic_speed_or_volume_a
+            span: 24
+            type: radio-button
+            options:
+              HE04|1|1: field.HE04.option.Not_a_problem_at_all
+              HE04|2|1: field.HE04.option.Minor_problem
+              HE04|3|1: field.HE04.option.Fairly_big_problem
+              HE04|4|1: field.HE04.option.Very_big_problem
+              HE04|5|1: field.HE04.option.Don_t_know
+              HE04|6|1: field.HE04.option.No_answer
+          - field: HE07
+            shortLabel: field.HE07.label.Does_lack_of_access_to_parks_or
+            span: 24
+            type: radio-button
+            options:
+              HE07|1|1: field.HE07.option.Not_a_problem_at_all
+              HE07|2|1: field.HE07.option.Minor_problem
+              HE07|3|1: field.HE07.option.Fairly_big_problem
+              HE07|4|1: field.HE07.option.Very_big_problem
+              HE07|5|1: field.HE07.option.Don_t_know
+              HE07|6|1: field.HE07.option.No_answer
+      - group: group.Series_2_Home
+        span: 24
+        fields:
+          - field: HE09
+            shortLabel: field.HE09.label.Thinking_about_the_last_12
+            span: 24
+            type: label
+          - field: HE10
+            shortLabel: field.HE10.label.Does_air_pollution_pose_a
+            span: 24
+            type: radio-button
+            options:
+              HE10|1|1: field.HE10.option.Not_at_all
+              HE10|2|1: field.HE10.option.Slightly
+              HE10|3|1: field.HE10.option.Moderately
+              HE10|4|1: field.HE10.option.A_lot
+              HE10|5|1: field.HE10.option.Extremely
+              HE10|6|1: field.HE10.option.Don_t_know
+              HE10|7|1: field.HE10.option.No_answer
+          - field: HE13
+            shortLabel: field.HE13.label.Is_traffic_noise_a_problem_road
+            span: 24
+            type: radio-button
+            options:
+              HE13|1|1: field.HE13.option.Not_at_all
+              HE13|2|1: field.HE13.option.Slightly
+              HE13|3|1: field.HE13.option.Moderately
+              HE13|4|1: field.HE13.option.A_lot
+              HE13|5|1: field.HE13.option.Extremely
+              HE13|6|1: field.HE13.option.Don_t_know
+              HE13|7|1: field.HE13.option.No_answer
+          - field: HE16
+            shortLabel: field.HE16.label.Does_noise_from_nearby
+            span: 24
+            type: radio-button
+            options:
+              HE16|1|1: field.HE16.option.Not_at_all
+              HE16|2|1: field.HE16.option.Slightly
+              HE16|3|1: field.HE16.option.Moderately
+              HE16|4|1: field.HE16.option.A_lot
+              HE16|5|1: field.HE16.option.Extremely
+              HE16|6|1: field.HE16.option.Don_t_know
+              HE16|7|1: field.HE16.option.No_answer
+  - section: section.Work_Absence
+    fields:
+      - field: AW01
+        shortLabel: field.AW01.label.In_the_past_12_months_were_you
+        span: 24
+        type: radio-button
+        options:
+          AW01|1|1: field.AW01.option.Yes
+          AW01|2|1: field.AW01.option.No
+      - field: AW02
+        shortLabel: field.AW02.label.In_the_past_12_months_how_many
+        span: 24
+        type: number-field
+        computedProperties:
+          hidden: return !hasOption(AW01[0],'1')
+      - field: AW03
+        shortLabel: field.AW03.label.What_is_the_main_reason_for
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(AW01[0],'1')
+        options:
+          AW03|1|1: field.AW03.option.Physical_health_problem
+          AW03|2|1: field.AW03.option.Fatigue_stress_or_burnout
+          AW03|3|1: field.AW03.option.Accident_or_injury
+          AW03|4|1: field.AW03.option.Other_reason
+          AW03|5|1: field.AW03.option.I_prefer_not_to_answer
+  - section: section.Medical_History
+    fields:
+      - group: group.Cardiovascular_history
+        span: 24
+        fields:
+          - field: CV00
+            shortLabel: field.CV00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: CV01
+            shortLabel: field.CV01.label.Has_a_doctor_ever_diagnosed_you
+            span: 24
+            type: checkbox
+            options:
+              CV01|1|1: field.CV01.option.High_blood_pressure
+              CV01|2|1: field.CV01.option.Coronary_artery_disease_angina
+              CV01|3|1: field.CV01.option.Myocardial_infarction
+              CV01|4|1: field.CV01.option.Heart_rhythm_disorder_e.g.
+              CV01|5|1: field.CV01.option.Heart_failure
+              CV01|6|1: field.CV01.option.Stroke_CVA_or_TIA
+              CV01|7|1: field.CV01.option.Peripheral_artery_disease
+              CV01|8|1: field.CV01.option.Other_cardiovascular_disease
+              CV01|9|1: field.CV01.option.None
+              CV01|10|1: field.CV01.option.I_don_t_know
+          - field: CV02
+            shortLabel: field.CV02.label.Are_you_currently_taking
+            span: 24
+            type: radio-button
+            options:
+              CV02|1|1: field.CV02.option.Yes
+              CV02|2|1: field.CV02.option.No
+              CV02|3|1: field.CV02.option.I_don_t_know
+          - field: CV03
+            shortLabel: field.CV03.label.In_recent_months_have_you
+            span: 24
+            type: checkbox
+            options:
+              CV03|1|1: field.CV03.option.Unusual_shortness_of_breath_on
+              CV03|2|1: field.CV03.option.Chest_pain_or_tightness
+              CV03|3|1: field.CV03.option.Palpitations_or_irregular
+              CV03|4|1: field.CV03.option.Dizziness_faintness_or_loss_of
+              CV03|5|1: field.CV03.option.Swelling_of_ankles_or_legs
+              CV03|6|1: field.CV03.option.None_of_these_symptoms
+          - field: CV04
+            shortLabel: field.CV04.label.Are_you_currently_being
+            span: 24
+            type: radio-button
+            options:
+              CV04|1|1: field.CV04.option.Yes
+              CV04|2|1: field.CV04.option.No
+              CV04|3|1: field.CV04.option.I_don_t_know
+      - group: group.Metabolic_Endocrine_history
+        span: 24
+        fields:
+          - field: EN00
+            shortLabel: field.EN00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: EN01
+            shortLabel: field.EN01.label.Has_a_doctor_ever_diagnosed_you
+            span: 24
+            type: checkbox
+            options:
+              EN01|1|1: field.EN01.option.Type_2_diabetes
+              EN01|2|1: field.EN01.option.Type_1_diabetes
+              EN01|3|1: field.EN01.option.Prediabetes_glucose_intolerance
+              EN01|4|1: field.EN01.option.High_cholesterol_dyslipidaemia
+              EN01|5|1: field.EN01.option.Thyroid_disease_hypo_or
+              EN01|6|1: field.EN01.option.Metabolic_syndrome
+              EN01|7|1: field.EN01.option.Other_metabolic_or_endocrine
+              EN01|8|1: field.EN01.option.None
+              EN01|9|1: field.EN01.option.I_don_t_know
+          - field: EN02
+            shortLabel: field.EN02.label.Are_you_currently_being
+            span: 24
+            type: radio-button
+            options:
+              EN02|1|1: field.EN02.option.Yes
+              EN02|2|1: field.EN02.option.No
+              EN02|3|1: field.EN02.option.I_don_t_know
+      - group: group.Respiratory_history
+        span: 24
+        fields:
+          - field: RS00
+            shortLabel: field.RS00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: RS01
+            shortLabel: field.RS01.label.Have_you_ever_been_diagnosed_by
+            span: 24
+            type: radio-button
+            options:
+              RS01|1|1: field.RS01.option.Yes
+              RS01|2|1: field.RS01.option.No
+              RS01|3|1: field.RS01.option.I_don_t_know_I_m_not_sure
+          - field: RS02
+            shortLabel: field.RS02.label.What_respiratory_diagnosis
+            span: 24
+            type: checkbox
+            options:
+              RS02|1|1: field.RS02.option.Asthma_current
+              RS02|2|1: field.RS02.option.Childhood_past_asthma
+              RS02|3|1: field.RS02.option.Chronic_obstructive_pulmonary
+              RS02|4|1: field.RS02.option.Recurrent_bronchitis
+              RS02|5|1: field.RS02.option.Pulmonary_fibrosis
+              RS02|6|1: field.RS02.option.Sarcoidosis
+              RS02|7|1: field.RS02.option.Allergic_alveolitis
+              RS02|8|1: field.RS02.option.Cystic_fibrosis
+              RS02|9|1: field.RS02.option.Other_diagnosed_respiratory
+              RS02|10|1: field.RS02.option.I_don_t_know_the_exact_diagnosis
+          - field: RS03
+            shortLabel: field.RS03.label.Are_you_currently_being_treated
+            span: 24
+            type: checkbox
+            options:
+              RS03|1|1: field.RS03.option.Inhaler_spray_e.g.
+              RS03|2|1: field.RS03.option.Night_time_ventilation_CPAP
+              RS03|3|1: field.RS03.option.Home_oxygen_therapy
+              RS03|4|1: field.RS03.option.Other_respiratory_treatment
+              RS03|5|1: field.RS03.option.No_respiratory_treatment
+          - field: RS04
+            shortLabel: field.RS04.label.Do_you_currently_have_one_or
+            span: 24
+            type: checkbox
+            options:
+              RS04|1|1: field.RS04.option.Shortness_of_breath_on_exertion
+              RS04|2|1: field.RS04.option.Wheezing
+              RS04|3|1: field.RS04.option.Chronic_cough
+              RS04|4|1: field.RS04.option.Persistent_fatigue_possibly
+              RS04|5|1: field.RS04.option.Significant_snoring
+              RS04|6|1: field.RS04.option.No_respiratory_symptoms
+      - group: group.Musculoskeletal_history
+        span: 24
+        fields:
+          - field: MQ00
+            shortLabel: field.MQ00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: MQ01
+            shortLabel: field.MQ01.label.Has_a_doctor_ever_diagnosed_you
+            span: 24
+            type: checkbox
+            options:
+              MQ01|1|1: field.MQ01.option.Chronic_low_back_pain_herniated
+              MQ01|2|1: field.MQ01.option.Chronic_neck_pain
+              MQ01|3|1: field.MQ01.option.Osteoarthritis_hip_knee_spine
+              MQ01|4|1: field.MQ01.option.Chronic_tendinitis_shoulder
+              MQ01|5|1: field.MQ01.option.Carpal_tunnel_syndrome
+              MQ01|6|1: field.MQ01.option.Work_related_musculoskeletal
+              MQ01|7|1: field.MQ01.option.Other_musculoskeletal_condition
+              MQ01|8|1: field.MQ01.option.None
+              MQ01|9|1: field.MQ01.option.I_don_t_know
+          - field: MQ02
+            shortLabel: field.MQ02.label.Are_you_currently_being_treated
+            span: 24
+            type: radio-button
+            options:
+              MQ02|1|1: field.MQ02.option.Yes
+              MQ02|2|1: field.MQ02.option.No
+              MQ02|3|1: field.MQ02.option.I_don_t_know
+          - field: MQ03
+            shortLabel: field.MQ03.label.In_recent_months_have_you
+            span: 24
+            type: checkbox
+            options:
+              MQ03|1|1: field.MQ03.option.Back_or_neck_pain
+              MQ03|2|1: field.MQ03.option.Shoulder_arm_or_wrist_pain
+              MQ03|3|1: field.MQ03.option.Hip_knee_or_ankle_pain
+              MQ03|4|1: field.MQ03.option.Prolonged_joint_stiffness
+              MQ03|5|1: field.MQ03.option.Decreased_mobility_or_strength
+              MQ03|6|1: field.MQ03.option.None_of_these_symptoms
+          - field: MQ04
+            shortLabel: field.MQ04.label.Do_these_pains_or_limitations
+            span: 24
+            type: radio-button
+            options:
+              MQ04|1|1: field.MQ04.option.Not_at_all
+              MQ04|2|1: field.MQ04.option.A_little
+              MQ04|3|1: field.MQ04.option.A_lot
+              MQ04|4|1: field.MQ04.option.Not_applicable_no_pain
+      - group: group.Neurological_history
+        span: 24
+        fields:
+          - field: NE00
+            shortLabel: field.NE00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: NE01
+            shortLabel: field.NE01.label.Has_a_doctor_ever_diagnosed_you
+            span: 24
+            type: checkbox
+            options:
+              NE01|1|1: field.NE01.option.Chronic_migraine
+              NE01|2|1: field.NE01.option.Epilepsy
+              NE01|3|1: field.NE01.option.Multiple_sclerosis
+              NE01|4|1: field.NE01.option.Parkinson_s_disease
+              NE01|5|1: field.NE01.option.Peripheral_neuropathy_tingling
+              NE01|6|1: field.NE01.option.Neurological_disorder_following
+              NE01|7|1: field.NE01.option.Other_neurological_disease
+              NE01|8|1: field.NE01.option.None
+              NE01|9|1: field.NE01.option.I_don_t_know
+          - field: NE02
+            shortLabel: field.NE02.label.Are_you_currently_being
+            span: 24
+            type: radio-button
+            options:
+              NE02|1|1: field.NE02.option.Yes
+              NE02|2|1: field.NE02.option.No
+              NE02|3|1: field.NE02.option.I_don_t_know
+          - field: NE03
+            shortLabel: field.NE03.label.In_recent_months_have_you
+            span: 24
+            type: checkbox
+            options:
+              NE03|1|1: field.NE03.option.Frequent_or_unusual_headaches
+              NE03|2|1: field.NE03.option.Dizziness_or_balance_problems
+              NE03|3|1: field.NE03.option.Numbness_tingling_or_loss_of
+              NE03|4|1: field.NE03.option.Unexplained_muscle_weakness
+              NE03|5|1: field.NE03.option.Concentration_or_memory_problems
+              NE03|6|1: field.NE03.option.Unusual_tremors
+              NE03|7|1: field.NE03.option.None_of_these_symptoms
+          - field: NE04
+            shortLabel: field.NE04.label.Do_these_symptoms_impact_your
+            span: 24
+            type: radio-button
+            options:
+              NE04|1|1: field.NE04.option.Not_at_all
+              NE04|2|1: field.NE04.option.A_little
+              NE04|3|1: field.NE04.option.A_lot
+              NE04|4|1: field.NE04.option.Not_applicable_no_symptoms
+      - group: group.Digestive_hepatic_history
+        span: 24
+        fields:
+          - field: DG00
+            shortLabel: field.DG00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: DG01
+            shortLabel: field.DG01.label.Has_a_doctor_ever_diagnosed_you
+            span: 24
+            type: checkbox
+            options:
+              DG01|1|1: field.DG01.option.Gastroesophageal_reflux_disease
+              DG01|2|1: field.DG01.option.Stomach_or_duodenal_ulcer
+              DG01|3|1: field.DG01.option.Irritable_bowel_syndrome_IBS
+              DG01|4|1: field.DG01.option.Inflammatory_bowel_disease
+              DG01|5|1: field.DG01.option.Liver_disease_fatty_liver
+              DG01|6|1: field.DG01.option.Digestive_polyps_or_history_of
+              DG01|7|1: field.DG01.option.Other_digestive_or_liver_disease
+              DG01|8|1: field.DG01.option.None
+              DG01|9|1: field.DG01.option.I_don_t_know
+          - field: DG02
+            shortLabel: field.DG02.label.Are_you_currently_being
+            span: 24
+            type: radio-button
+            options:
+              DG02|1|1: field.DG02.option.Yes
+              DG02|2|1: field.DG02.option.No
+              DG02|3|1: field.DG02.option.I_don_t_know
+          - field: DG03
+            shortLabel: field.DG03.label.In_recent_months_have_you
+            span: 24
+            type: checkbox
+            options:
+              DG03|1|1: field.DG03.option.Heartburn_or_acid_reflux
+              DG03|2|1: field.DG03.option.Recurrent_abdominal_pain
+              DG03|3|1: field.DG03.option.Significant_bloating_or
+              DG03|4|1: field.DG03.option.Bowel_irregularities_persistent
+              DG03|5|1: field.DG03.option.Frequent_nausea
+              DG03|6|1: field.DG03.option.Unusual_stools_colour_appearance
+              DG03|7|1: field.DG03.option.None_of_these_symptoms
+          - field: DG04
+            shortLabel: field.DG04.label.Do_these_digestive_issues
+            span: 24
+            type: radio-button
+            options:
+              DG04|1|1: field.DG04.option.Not_at_all
+              DG04|2|1: field.DG04.option.A_little
+              DG04|3|1: field.DG04.option.A_lot
+              DG04|4|1: field.DG04.option.Not_applicable_no_symptoms
+      - group: group.Urinary_history
+        span: 24
+        fields:
+          - field: UR00
+            shortLabel: field.UR00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: UR01
+            shortLabel: field.UR01.label.Has_a_doctor_ever_diagnosed_you
+            span: 24
+            type: checkbox
+            options:
+              UR01|1|1: field.UR01.option.Chronic_kidney_disease
+              UR01|2|1: field.UR01.option.Recurrent_kidney_stones
+              UR01|3|1: field.UR01.option.Recurrent_urinary_tract
+              UR01|4|1: field.UR01.option.Chronic_kidney_or_urinary
+              UR01|5|1: field.UR01.option.None
+              UR01|6|1: field.UR01.option.I_don_t_know
+          - field: UR02
+            shortLabel: field.UR02.label.Are_you_currently_being
+            span: 24
+            type: radio-button
+            options:
+              UR02|1|1: field.UR02.option.Yes
+              UR02|2|1: field.UR02.option.No
+              UR02|3|1: field.UR02.option.I_don_t_know
+          - field: UR03
+            shortLabel: field.UR03.label.In_recent_months_have_you
+            span: 24
+            type: checkbox
+            options:
+              UR03|1|1: field.UR03.option.Frequent_need_to_urinate
+              UR03|2|1: field.UR03.option.Night_time_urination_nocturia
+              UR03|3|1: field.UR03.option.Pain_or_burning_during_urination
+              UR03|4|1: field.UR03.option.Difficulty_completely_emptying
+              UR03|5|1: field.UR03.option.Unexplained_lower_back_pain
+              UR03|6|1: field.UR03.option.None_of_these_symptoms
+          - field: UR04
+            shortLabel: field.UR04.label.Do_these_urinary_issues_impact
+            span: 24
+            type: radio-button
+            options:
+              UR04|1|1: field.UR04.option.Not_at_all
+              UR04|2|1: field.UR04.option.A_little
+              UR04|3|1: field.UR04.option.A_lot
+              UR04|4|1: field.UR04.option.Not_applicable_no_symptoms
+      - group: group.Personal_history_of_cancer
+        span: 24
+        fields:
+          - field: CA00
+            shortLabel: field.CA00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: CA01
+            shortLabel: field.CA01.label.Has_a_doctor_ever_diagnosed_you
+            span: 24
+            type: radio-button
+            options:
+              CA01|1|1: field.CA01.option.Yes
+              CA01|2|1: field.CA01.option.No
+              CA01|3|1: field.CA01.option.I_don_t_know
+          - field: CA02
+            shortLabel: field.CA02.label.What_type_of_cancer_Multiple
+            span: 24
+            type: checkbox
+            options:
+              CA02|1|1: field.CA02.option.Breast
+              CA02|2|1: field.CA02.option.Prostate
+              CA02|3|1: field.CA02.option.Lung
+              CA02|4|1: field.CA02.option.Colorectal
+              CA02|5|1: field.CA02.option.Skin
+              CA02|6|1: field.CA02.option.Gynaecological
+              CA02|7|1: field.CA02.option.Other_specify
+          - field: CA02_PRECISION
+            shortLabel: field.CA02_PRECISION.label.Specify_the_type_of_cancer
+            span: 24
+            type: text
+      - group: group.Other_medical_history
+        span: 24
+        fields:
+          - field: OT00
+            shortLabel: field.OT00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: OT01
+            shortLabel: field.OT01.label.Apart_from_what_has_already
+            span: 24
+            type: radio-button
+            options:
+              OT01|1|1: field.OT01.option.Yes
+              OT01|2|1: field.OT01.option.No
+          - field: OT02
+            shortLabel: field.OT02.label.Can_you_specify_in_a_few_words
+            span: 24
+            type: text
+          - field: OT03
+            shortLabel: field.OT03.label.Do_these_issues_impact_your
+            span: 24
+            type: radio-button
+            options:
+              OT03|1|1: field.OT03.option.Not_at_all
+              OT03|2|1: field.OT03.option.A_little
+              OT03|3|1: field.OT03.option.A_lot
+              OT03|4|1: field.OT03.option.Not_applicable_no_symptoms
+          - field: OT04
+            shortLabel: field.OT04.label.Are_you_generally_up_to_date
+            span: 24
+            type: radio-button
+            options:
+              OT04|1|1: field.OT04.option.Yes
+              OT04|2|1: field.OT04.option.No
+              OT04|3|1: field.OT04.option.I_don_t_know
+          - field: OT05
+            shortLabel: field.OT05.label.When_did_you_last_have_your
+            span: 24
+            type: radio-button
+            options:
+              OT05|1|1: field.OT05.option.Less_than_1_year_ago
+              OT05|2|1: field.OT05.option.1_to_2_years_ago
+              OT05|3|1: field.OT05.option.More_than_2_years_ago
+              OT05|4|1: field.OT05.option.I_have_never_had_a_check_up
+              OT05|5|1: field.OT05.option.I_don_t_remember
+          - field: OT06
+            shortLabel: field.OT06.label.Have_you_ever_had_a_major
+            span: 24
+            type: radio-button
+            options:
+              OT06|1|1: field.OT06.option.Yes
+              OT06|2|1: field.OT06.option.No
+              OT06|3|1: field.OT06.option.I_don_t_remember
+          - field: OT07
+            shortLabel: field.OT07.label.Which_one_if_you_remember
+            span: 24
+            type: text
+      - group: group.Family_history
+        span: 24
+        fields:
+          - field: FA00
+            shortLabel: field.FA00.label.The_following_questions_concern
+            span: 24
+            type: label
+            standalone: true
+          - field: FA01
+            shortLabel: field.FA01.label.Has_a_close_family_member_had
+            span: 24
+            type: radio-button
+            options:
+              FA01|1|1: field.FA01.option.Yes
+              FA01|2|1: field.FA01.option.No
+              FA01|3|1: field.FA01.option.I_don_t_know
+          - field: FA02
+            shortLabel: field.FA02.label.Is_there_a_history_of_cancer_in
+            span: 24
+            type: radio-button
+            options:
+              FA02|1|1: field.FA02.option.Yes
+              FA02|2|1: field.FA02.option.No
+              FA02|3|1: field.FA02.option.I_don_t_know
+          - field: FA03
+            shortLabel: field.FA03.label.Do_close_family_members_have
+            span: 24
+            type: radio-button
+            options:
+              FA03|1|1: field.FA03.option.Yes
+              FA03|2|1: field.FA03.option.No
+              FA03|3|1: field.FA03.option.I_don_t_know
+  - section: section.Dental_Health
+    fields:
+      - field: DHDC01
+        shortLabel: field.DHDC01.label.How_often_do_you_usually_brush
+        span: 24
+        type: radio-button
+        options:
+          DHDC01|1|1: field.DHDC01.option.More_than_twice_a_day
+          DHDC01|2|1: field.DHDC01.option.Twice_a_day
+          DHDC01|3|1: field.DHDC01.option.Once_a_day
+          DHDC01|4|1: field.DHDC01.option.Less_than_once_a_day
+          DHDC01|5|1: field.DHDC01.option.Never
+          DHDC01|6|1: field.DHDC01.option.Not_applicable_according_to
+      - field: DHDC02
+        shortLabel: field.DHDC02.label.Overall_how_would_you_rate_the
+        span: 24
+        type: radio-button
+        options:
+          DHDC02|1|1: field.DHDC02.option.Very_good
+          DHDC02|2|1: field.DHDC02.option.Good
+          DHDC02|3|1: field.DHDC02.option.Neither_good_nor_bad
+          DHDC02|4|1: field.DHDC02.option.Bad
+          DHDC02|5|1: field.DHDC02.option.Very_bad
+      - field: DHDC03
+        shortLabel: field.DHDC03.label.In_the_past_12_months_have_you
+        span: 24
+        type: radio-button
+        options:
+          DHDC03|1|1: field.DHDC03.option.Yes
+          DHDC03|2|1: field.DHDC03.option.No
+      - field: DHDC04
+        shortLabel: field.DHDC04.label.When_did_you_last_visit_your
+        span: 24
+        type: radio-button
+        options:
+          DHDC04|1|1: field.DHDC04.option.Less_than_6_months_ago
+          DHDC04|2|1: field.DHDC04.option.6_months_or_more_ago_but_less
+          DHDC04|3|1: field.DHDC04.option.12_months_or_more_ago
+          DHDC04|4|1: field.DHDC04.option.Never
+          DHDC04|5|1: field.DHDC04.option.Don_t_know
+  - section: section.Cancer_Screening
+    fields:
+      - group: group.Family_history_of_cancer
+        span: 24
+        fields:
+          - field: SC02
+            shortLabel: field.SC02.label.Is_there_a_history_of_cancer_in
+            span: 24
+            type: radio-button
+            options:
+              SC02|1|1: field.SC02.option.Yes
+              SC02|2|1: field.SC02.option.No
+              SC02|3|1: field.SC02.option.I_don_t_know
+      - group: group.Prostate_cancer.
+        span: 24
+        computedProperties:
+          hidden: return !(patient.birthSex === 'Male' || patient.gender === 'Male')
+        fields:
+          - field: SC20
+            shortLabel: field.SC20.label.IPSS_International_Prostate
+            span: 24
+            type: label
+          - field: SC21
+            shortLabel: field.SC21.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SC21|0|1: field.SC21.option.Never
+              SC21|1|1: field.SC21.option.About_1_time_in_5
+              SC21|2|1: field.SC21.option.About_1_time_in_3
+              SC21|3|1: field.SC21.option.About_1_time_in_2
+              SC21|4|1: field.SC21.option.About_2_times_in_3
+              SC21|5|1: field.SC21.option.Almost_always
+          - field: SC22
+            shortLabel: field.SC22.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SC22|0|1: field.SC22.option.Never
+              SC22|1|1: field.SC22.option.About_1_time_in_5
+              SC22|2|1: field.SC22.option.About_1_time_in_3
+              SC22|3|1: field.SC22.option.About_1_time_in_2
+              SC22|4|1: field.SC22.option.About_2_times_in_3
+              SC22|5|1: field.SC22.option.Almost_always
+          - field: SC23
+            shortLabel: field.SC23.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SC23|0|1: field.SC23.option.Never
+              SC23|1|1: field.SC23.option.About_1_time_in_5
+              SC23|2|1: field.SC23.option.About_1_time_in_3
+              SC23|3|1: field.SC23.option.About_1_time_in_2
+              SC23|4|1: field.SC23.option.About_2_times_in_3
+              SC23|5|1: field.SC23.option.Almost_always
+          - field: SC24
+            shortLabel: field.SC24.label.In_the_past_month_after_feeling
+            span: 24
+            type: radio-button
+            options:
+              SC24|0|1: field.SC24.option.Never
+              SC24|1|1: field.SC24.option.About_1_time_in_5
+              SC24|2|1: field.SC24.option.About_1_time_in_3
+              SC24|3|1: field.SC24.option.About_1_time_in_2
+              SC24|4|1: field.SC24.option.About_2_times_in_3
+              SC24|5|1: field.SC24.option.Almost_always
+          - field: SC25
+            shortLabel: field.SC25.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SC25|0|1: field.SC25.option.Never
+              SC25|1|1: field.SC25.option.About_1_time_in_5
+              SC25|2|1: field.SC25.option.About_1_time_in_3
+              SC25|3|1: field.SC25.option.About_1_time_in_2
+              SC25|4|1: field.SC25.option.About_2_times_in_3
+              SC25|5|1: field.SC25.option.Almost_always
+          - field: SC26
+            shortLabel: field.SC26.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SC26|0|1: field.SC26.option.Never
+              SC26|1|1: field.SC26.option.About_1_time_in_5
+              SC26|2|1: field.SC26.option.About_1_time_in_3
+              SC26|3|1: field.SC26.option.About_1_time_in_2
+              SC26|4|1: field.SC26.option.About_2_times_in_3
+              SC26|5|1: field.SC26.option.Almost_always
+          - field: SC27
+            shortLabel: field.SC27.label.In_the_past_month_how_many
+            span: 24
+            type: radio-button
+            options:
+              SC27|0|1: field.SC27.option.Never
+              SC27|1|1: field.SC27.option.1_time
+              SC27|2|1: field.SC27.option.2_times
+              SC27|3|1: field.SC27.option.3_times
+              SC27|4|1: field.SC27.option.4_times
+              SC27|5|1: field.SC27.option.5_times
+          - field: SC28
+            shortLabel: field.SC28.label.Total_score
+            span: 24
+            type: number-field
+            styleOptions:
+              decimalPlaces: 0
+            computedProperties:
+              value: |
+                return { content: { '*': { 
+                  type: 'number', 
+                  value: score(SC27[0])+score(SC21[0])+score(SC22[0])+score(SC23[0])+score(SC24[0])+score(SC25[0])+score(SC26[0]) 
+                } }, codes: [] }
+          - field: SC29
+            shortLabel: field.SC29.label.IPSS_notes_0_7_mild_8_19
+            span: 24
+            type: label
+      - group: group.Colorectal_cancer_screening
+        span: 24
+        fields:
+          - field: SC31
+            shortLabel: field.SC31.label.There_is_a_screening_test_for
+            span: 24
+            type: radio-button
+            options:
+              SC31|1|1: field.SC31.option.Yes
+              SC31|2|1: field.SC31.option.No
+          - field: SC32
+            shortLabel: field.SC32.label.When_did_you_last_have_a_test
+            span: 24
+            type: radio-button
+            computedProperties:
+              hidden: "!hasOption(SC31[0],'1')"
+            options:
+              SC32|1|1: field.SC32.option.Less_than_2_years_ago
+              SC32|2|1: field.SC32.option.2_years_or_more_ago
+              SC32|3|1: field.SC32.option.Never
+              SC32|4|1: field.SC32.option.I_don_t_know
+          - field: SC33
+            shortLabel: field.SC33.label.A_more_thorough_examination
+            span: 24
+            type: radio-button
+            options:
+              SC33|1|1: field.SC33.option.Yes
+              SC33|2|1: field.SC33.option.No
+          - field: SC34
+            shortLabel: field.SC34.label.When_did_you_last_have_a
+            span: 24
+            type: radio-button
+            computedProperties:
+              hidden: "!hasOption(SC33[0],'1')"
+            options:
+              SC34|1|1: field.SC34.option.Less_than_5_years_ago
+              SC34|2|1: field.SC34.option.More_than_5_years_ago_but_less
+              SC34|3|1: field.SC34.option.More_than_10_years_ago
+      - group: group.Breast_cancer_screening
+        span: 24
+        fields:
+          - field: SC36
+            shortLabel: field.SC36.label.Have_you_ever_had_a_mammography
+            span: 24
+            type: radio-button
+            options:
+              SC36|1|1: field.SC36.option.Yes
+              SC36|2|1: field.SC36.option.No
+              SC36|3|1: field.SC36.option.I_don_t_know
+          - field: SC37
+            shortLabel: field.SC37.label.When_did_you_last_have_a
+            span: 24
+            type: radio-button
+            computedProperties:
+              hidden: "!hasOption(SC36[0],'1')"
+            options:
+              SC37|1|1: field.SC37.option.Less_than_2_years_ago
+              SC37|2|1: field.SC37.option.2_years_or_more_ago
+              SC37|3|1: field.SC37.option.I_don_t_know
+      - group: group.Cervical_cancer_screening
+        span: 24
+        fields:
+          - field: SC39
+            shortLabel: field.SC39.label.Have_you_ever_had_a_cervical
+            span: 24
+            type: radio-button
+            options:
+              SC39|1|1: field.SC39.option.Yes
+              SC39|2|1: field.SC39.option.No
+          - field: SC40
+            shortLabel: field.SC40.label.When_did_you_last_have_a
+            span: 24
+            type: radio-button
+            computedProperties:
+              hidden: "!hasOption(SC39[0],'1')"
+            options:
+              SC40|1|1: field.SC40.option.Less_than_3_years_ago
+              SC40|2|1: field.SC40.option.3_years_or_more_ago
+              SC40|3|1: field.SC40.option.I_don_t_know
+      - group: group.Skin_cancer
+        span: 24
+        fields:
+          - field: SC42
+            shortLabel: field.SC42.label.Do_you_have_more_than_50_moles
+            span: 24
+            type: radio-button
+            options:
+              SC42|1|1: field.SC42.option.Yes
+              SC42|2|1: field.SC42.option.No
+              SC42|3|1: field.SC42.option.I_don_t_know
+          - field: SC44
+            shortLabel: field.SC44.label.How_does_your_skin_generally
+            span: 24
+            type: radio-button
+            options:
+              SC44|1|1: field.SC44.option.I_burn_easily_I_tan_little_or
+              SC44|2|1: field.SC44.option.I_sometimes_burn_then_tan
+              SC44|3|1: field.SC44.option.I_tan_easily_and_rarely_burn
+              SC44|4|1: field.SC44.option.I_don_t_know
+          - field: SC45
+            shortLabel: field.SC45.label.Have_you_been_repeatedly
+            span: 24
+            type: radio-button
+            options:
+              SC45|1|1: field.SC45.option.Yes
+              SC45|2|1: field.SC45.option.No
+              SC45|3|1: field.SC45.option.I_don_t_know
+          - field: SC46
+            shortLabel: field.SC46.label.Have_you_ever_used_tanning_beds
+            span: 24
+            type: radio-button
+            options:
+              SC46|1|1: field.SC46.option.Never
+              SC46|2|1: field.SC46.option.Occasionally
+              SC46|3|1: field.SC46.option.Regularly_in_the_past_or
+          - field: SC47
+            shortLabel: field.SC47.label.Have_you_ever_had_your_moles_or
+            span: 24
+            type: radio-button
+            options:
+              SC47|1|1: field.SC47.option.Yes
+              SC47|2|1: field.SC47.option.No
+              SC47|3|1: field.SC47.option.I_don_t_know
+      - group: group.Lung_cancer
+        span: 24
+        fields:
+          - field: SC48
+            shortLabel: field.SC48.label.Have_you_smoked_the_equivalent
+            span: 24
+            type: radio-button
+            options:
+              SC48|1|1: field.SC48.option.Yes
+              SC48|2|1: field.SC48.option.No
+              SC48|3|1: field.SC48.option.I_don_t_know
+  - section: section.Cardiovascular_Diseases
+    fields:
+      - field: PR01
+        shortLabel: field.PR01.label.Has_your_blood_pressure_ever
+        span: 24
+        type: radio-button
+        options:
+          PR01|1|1: field.PR01.option.Yes
+          PR01|2|1: field.PR01.option.No
+          PR01|3|1: field.PR01.option.I_don_t_know
+      - field: PR03
+        shortLabel: field.PR03.label.If_your_blood_pressure_was
+        span: 24
+        type: checkbox
+        computedProperties:
+          hidden: "!hasOption(PR01[0],'1')"
+        options:
+          PR03|1|1: field.PR03.option.Above_140_90_mmHg
+          PR03|2|1: field.PR03.option.Between_120_70_and_140_90_mmHg
+          PR03|3|1: field.PR03.option.Below_120_70_mmHg
+          PR03|4|1: field.PR03.option.I_don_t_remember
+      - field: PR04
+        shortLabel: field.PR04.label.When_did_you_last_have_a_blood
+        span: 24
+        type: radio-button
+        options:
+          PR04|1|1: field.PR04.option.Less_than_a_year_ago
+          PR04|2|1: field.PR04.option.More_than_1_year_ago
+          PR04|5|1: field.PR04.option.I_don_t_remember
+  - section: section.Physical_Pain
+    fields:
+      - field: PI02
+        shortLabel: field.PI02.label.Do_you_currently_experience
+        span: 24
+        type: radio-button
+        options:
+          PI02|1|1: field.PI02.option.Yes
+          PI02|2|1: field.PI02.option.No
+  - section: section.Mental_Health
+    fields:
+      - group: group.Perceived_stress
+        span: 24
+        fields:
+          - field: SM02
+            shortLabel: field.SM02.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM02|0|1: field.SM02.option.Never
+              SM02|1|1: field.SM02.option.Almost_never
+              SM02|2|1: field.SM02.option.Sometimes
+              SM02|3|1: field.SM02.option.Often
+              SM02|4|1: field.SM02.option.Very_often
+          - field: SM03
+            shortLabel: field.SM03.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM03|0|1: field.SM03.option.Never
+              SM03|1|1: field.SM03.option.Almost_never
+              SM03|2|1: field.SM03.option.Sometimes
+              SM03|3|1: field.SM03.option.Often
+              SM03|4|1: field.SM03.option.Very_often
+          - field: SM04
+            shortLabel: field.SM04.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM04|0|1: field.SM04.option.Never
+              SM04|1|1: field.SM04.option.Almost_never
+              SM04|2|1: field.SM04.option.Sometimes
+              SM04|3|1: field.SM04.option.Often
+              SM04|4|1: field.SM04.option.Very_often
+          - field: SM05
+            shortLabel: field.SM05.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM05|4|1: field.SM05.option.Never
+              SM05|3|1: field.SM05.option.Almost_never
+              SM05|2|1: field.SM05.option.Sometimes
+              SM05|1|1: field.SM05.option.Often
+              SM05|0|1: field.SM05.option.Very_often
+          - field: SM06
+            shortLabel: field.SM06.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM06|4|1: field.SM06.option.Never
+              SM06|3|1: field.SM06.option.Almost_never
+              SM06|2|1: field.SM06.option.Sometimes
+              SM06|1|1: field.SM06.option.Often
+              SM06|0|1: field.SM06.option.Very_often
+          - field: SM07
+            shortLabel: field.SM07.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM07|0|1: field.SM07.option.Never
+              SM07|1|1: field.SM07.option.Almost_never
+              SM07|2|1: field.SM07.option.Sometimes
+              SM07|3|1: field.SM07.option.Often
+              SM07|4|1: field.SM07.option.Very_often
+          - field: SM08
+            shortLabel: field.SM08.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM08|4|1: field.SM08.option.Never
+              SM08|3|1: field.SM08.option.Almost_never
+              SM08|2|1: field.SM08.option.Sometimes
+              SM08|1|1: field.SM08.option.Often
+              SM08|0|1: field.SM08.option.Very_often
+          - field: SM09
+            shortLabel: field.SM09.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM09|4|1: field.SM09.option.Never
+              SM09|3|1: field.SM09.option.Almost_never
+              SM09|2|1: field.SM09.option.Sometimes
+              SM09|1|1: field.SM09.option.Often
+              SM09|0|1: field.SM09.option.Very_often
+          - field: SM10
+            shortLabel: field.SM10.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM10|0|1: field.SM10.option.Never
+              SM10|1|1: field.SM10.option.Almost_never
+              SM10|2|1: field.SM10.option.Sometimes
+              SM10|3|1: field.SM10.option.Often
+              SM10|4|1: field.SM10.option.Very_often
+          - field: SM11
+            shortLabel: field.SM11.label.In_the_past_month_how_often
+            span: 24
+            type: radio-button
+            options:
+              SM11|0|1: field.SM11.option.Never
+              SM11|1|1: field.SM11.option.Almost_never
+              SM11|2|1: field.SM11.option.Sometimes
+              SM11|3|1: field.SM11.option.Often
+              SM11|4|1: field.SM11.option.Very_often
+          - field: SM12
+            shortLabel: field.SM12.label.Total_score
+            span: 24
+            type: number-field
+            styleOptions:
+              decimalPlaces: 0
+            computedProperties:
+              value: |
+                return { content: { '*': { 
+                  type: 'number', 
+                  value: (score(SM11[0])+score(SM02[0])+score(SM03[0])+score(SM04[0])+score(SM05[0])+score(SM06[0])+score(SM07[0])+score(SM08[0])+score(SM09[0])+score(SM10[0])) 
+                } }, codes: [] }
+      - group: group.Overall_well_being_energy_and
+        span: 24
+        fields:
+          - field: SM14
+            shortLabel: field.SM14.label.On_a_scale_of_0_to_10_where_0
+            span: 24
+            type: number-field
+          - field: SM15
+            shortLabel: field.SM15.label.In_recent_weeks_to_what_extent
+            span: 24
+            type: number-field
+          - field: SM16
+            shortLabel: field.SM16.label.In_recent_weeks_to_what_extent
+            span: 24
+            type: number-field
+      - group: group.GAD_7_Scale_anxiety_disorder
+        span: 24
+        fields:
+          - field: SM35
+            shortLabel: field.SM35.label.Over_the_last_2_weeks_how_often
+            span: 24
+            type: label
+          - field: SM36
+            shortLabel: field.SM36.label.Feeling_nervous_anxious_or_on
+            span: 24
+            type: radio-button
+            options:
+              SM36|0|1: field.SM36.option.Never
+              SM36|1|1: field.SM36.option.Several_days
+              SM36|2|1: field.SM36.option.More_than_half_the_days
+              SM36|3|1: field.SM36.option.Nearly_every_day
+          - field: SM37
+            shortLabel: field.SM37.label.Not_being_able_to_stop_or
+            span: 24
+            type: radio-button
+            options:
+              SM37|0|1: field.SM37.option.Never
+              SM37|1|1: field.SM37.option.Several_days
+              SM37|2|1: field.SM37.option.More_than_half_the_days
+              SM37|3|1: field.SM37.option.Nearly_every_day
+          - field: SM38
+            shortLabel: field.SM38.label.Worrying_too_much_about
+            span: 24
+            type: radio-button
+            options:
+              SM38|0|1: field.SM38.option.Never
+              SM38|1|1: field.SM38.option.Several_days
+              SM38|2|1: field.SM38.option.More_than_half_the_days
+              SM38|3|1: field.SM38.option.Nearly_every_day
+          - field: SM39
+            shortLabel: field.SM39.label.Trouble_relaxing
+            span: 24
+            type: radio-button
+            options:
+              SM39|0|1: field.SM39.option.Never
+              SM39|1|1: field.SM39.option.Several_days
+              SM39|2|1: field.SM39.option.More_than_half_the_days
+              SM39|3|1: field.SM39.option.Nearly_every_day
+          - field: SM40
+            shortLabel: field.SM40.label.Being_so_restless_that_it_is
+            span: 24
+            type: radio-button
+            options:
+              SM40|0|1: field.SM40.option.Never
+              SM40|1|1: field.SM40.option.Several_days
+              SM40|2|1: field.SM40.option.More_than_half_the_days
+              SM40|3|1: field.SM40.option.Nearly_every_day
+          - field: SM41
+            shortLabel: field.SM41.label.Becoming_easily_annoyed_or
+            span: 24
+            type: radio-button
+            options:
+              SM41|0|1: field.SM41.option.Never
+              SM41|1|1: field.SM41.option.Several_days
+              SM41|2|1: field.SM41.option.More_than_half_the_days
+              SM41|3|1: field.SM41.option.Nearly_every_day
+          - field: SM42
+            shortLabel: field.SM42.label.Feeling_afraid_as_if_something
+            span: 24
+            type: radio-button
+            options:
+              SM42|0|1: field.SM42.option.Never
+              SM42|1|1: field.SM42.option.Several_days
+              SM42|2|1: field.SM42.option.More_than_half_the_days
+              SM42|3|1: field.SM42.option.Nearly_every_day
+          - field: SM43
+            shortLabel: field.SM43.label.Total_score
+            span: 24
+            type: number-field
+            styleOptions:
+              decimalPlaces: 0
+            computedProperties:
+              value: |
+                return { content: { '*': { 
+                  type: 'number', 
+                  value: (score(SM36[0])+score(SM37[0])+score(SM38[0])+score(SM39[0])+score(SM40[0])+score(SM41[0])+score(SM42[0])) 
+                } }, codes: [] }
+      - group: group.PHQ_9_Scale_depression_screening
+        span: 24
+        fields:
+          - field: SM45
+            shortLabel: field.SM45.label.Please_answer_each_question_by
+            span: 24
+            type: label
+          - field: SM46
+            shortLabel: field.SM46.label.Over_the_last_two_weeks_how
+            span: 24
+            type: label
+          - field: SM47
+            shortLabel: field.SM47.label.Little_interest_or_pleasure_in
+            span: 24
+            type: radio-button
+            options:
+              SM47|0|1: field.SM47.option.Never
+              SM47|1|1: field.SM47.option.Several_days
+              SM47|2|1: field.SM47.option.More_than_half_the_days
+              SM47|3|1: field.SM47.option.Nearly_every_day
+          - field: SM48
+            shortLabel: field.SM48.label.Feeling_down_depressed_or
+            span: 24
+            type: radio-button
+            options:
+              SM48|0|1: field.SM48.option.Never
+              SM48|1|1: field.SM48.option.Several_days
+              SM48|2|1: field.SM48.option.More_than_half_the_days
+              SM48|3|1: field.SM48.option.Nearly_every_day
+          - field: SM49
+            shortLabel: field.SM49.label.Trouble_falling_asleep_staying
+            span: 24
+            type: radio-button
+            options:
+              SM49|0|1: field.SM49.option.Never
+              SM49|1|1: field.SM49.option.Several_days
+              SM49|2|1: field.SM49.option.More_than_half_the_days
+              SM49|3|1: field.SM49.option.Nearly_every_day
+          - field: SM50
+            shortLabel: field.SM50.label.Feeling_tired_or_having_little
+            span: 24
+            type: radio-button
+            options:
+              SM50|0|1: field.SM50.option.Never
+              SM50|1|1: field.SM50.option.Several_days
+              SM50|2|1: field.SM50.option.More_than_half_the_days
+              SM50|3|1: field.SM50.option.Nearly_every_day
+          - field: SM51
+            shortLabel: field.SM51.label.Poor_appetite_or_overeating
+            span: 24
+            type: radio-button
+            options:
+              SM51|0|1: field.SM51.option.Never
+              SM51|1|1: field.SM51.option.Several_days
+              SM51|2|1: field.SM51.option.More_than_half_the_days
+              SM51|3|1: field.SM51.option.Nearly_every_day
+          - field: SM52
+            shortLabel: field.SM52.label.Feeling_bad_about_yourself_or
+            span: 24
+            type: radio-button
+            options:
+              SM52|0|1: field.SM52.option.Never
+              SM52|1|1: field.SM52.option.Several_days
+              SM52|2|1: field.SM52.option.More_than_half_the_days
+              SM52|3|1: field.SM52.option.Nearly_every_day
+          - field: SM53
+            shortLabel: field.SM53.label.Trouble_concentrating_on_things
+            span: 24
+            type: radio-button
+            options:
+              SM53|0|1: field.SM53.option.Never
+              SM53|1|1: field.SM53.option.Several_days
+              SM53|2|1: field.SM53.option.More_than_half_the_days
+              SM53|3|1: field.SM53.option.Nearly_every_day
+          - field: SM54
+            shortLabel: field.SM54.label.Moving_or_speaking_so_slowly
+            span: 24
+            type: radio-button
+            options:
+              SM54|0|1: field.SM54.option.Never
+              SM54|1|1: field.SM54.option.Several_days
+              SM54|2|1: field.SM54.option.More_than_half_the_days
+              SM54|3|1: field.SM54.option.Nearly_every_day
+          - field: SM55
+            shortLabel: field.SM55.label.Thoughts_that_you_would_be
+            span: 24
+            type: radio-button
+            options:
+              SM55|0|1: field.SM55.option.Never
+              SM55|1|1: field.SM55.option.Several_days
+              SM55|2|1: field.SM55.option.More_than_half_the_days
+              SM55|3|1: field.SM55.option.Nearly_every_day
+          - field: SM56
+            shortLabel: field.SM56.label.Total_score
+            span: 24
+            type: number-field
+            styleOptions:
+              decimalPlaces: 0
+            computedProperties:
+              value: |
+                return { content: { '*': { 
+                  type: 'number', 
+                  value: (score(SM47[0])+score(SM48[0])+score(SM49[0])+score(SM50[0])+score(SM51[0])+score(SM52[0])+score(SM53[0])+score(SM54[0])+score(SM55[0])) 
+                } }, codes: [] }
+          - field: SM57
+            shortLabel: field.SM57.label.If_the_patient_answers_yes_to
+            span: 24
+            type: label
+          - field: SM58
+            shortLabel: field.SM58.label.If_you_checked_off_any_problems
+            span: 24
+            type: radio-button
+            options:
+              SM58|1|1: field.SM58.option.Not_difficult_at_all
+              SM58|2|1: field.SM58.option.Somewhat_difficult
+              SM58|3|1: field.SM58.option.Very_difficult
+              SM58|4|1: field.SM58.option.Extremely_difficult
+      - group: group.Depression_and_anxiety_disorders
+        span: 24
+        fields:
+          - field: SM60
+            shortLabel: field.SM60.label.Over_the_last_2_weeks_how_often
+            span: 24
+            type: label
+          - field: SM61
+            shortLabel: field.SM61.label.Feeling_nervous_anxious_or_on
+            span: 24
+            type: radio-button
+            options:
+              SM61|1|1: field.SM61.option.Not_at_all
+              SM61|2|1: field.SM61.option.Several_days
+              SM61|3|1: field.SM61.option.More_than_half_the_days
+              SM61|4|1: field.SM61.option.Nearly_every_day
+          - field: SM62
+            shortLabel: field.SM62.label.Not_being_able_to_stop_or
+            span: 24
+            type: radio-button
+            options:
+              SM62|1|1: field.SM62.option.Not_at_all
+              SM62|2|1: field.SM62.option.Several_days
+              SM62|3|1: field.SM62.option.More_than_half_the_days
+              SM62|4|1: field.SM62.option.Nearly_every_day
+          - field: SM63
+            shortLabel: field.SM63.label.Worrying_too_much_about
+            span: 24
+            type: radio-button
+            options:
+              SM63|1|1: field.SM63.option.Not_at_all
+              SM63|2|1: field.SM63.option.Several_days
+              SM63|3|1: field.SM63.option.More_than_half_the_days
+              SM63|4|1: field.SM63.option.Nearly_every_day
+          - field: SM64
+            shortLabel: field.SM64.label.Having_trouble_relaxing
+            span: 24
+            type: radio-button
+            options:
+              SM64|1|1: field.SM64.option.Not_at_all
+              SM64|2|1: field.SM64.option.Several_days
+              SM64|3|1: field.SM64.option.More_than_half_the_days
+              SM64|4|1: field.SM64.option.Nearly_every_day
+          - field: SM65
+            shortLabel: field.SM65.label.Being_so_restless_that_it_is
+            span: 24
+            type: radio-button
+            options:
+              SM65|1|1: field.SM65.option.Not_at_all
+              SM65|2|1: field.SM65.option.Several_days
+              SM65|3|1: field.SM65.option.More_than_half_the_days
+              SM65|4|1: field.SM65.option.Nearly_every_day
+          - field: SM66
+            shortLabel: field.SM66.label.Being_easily_annoyed_or
+            span: 24
+            type: radio-button
+            options:
+              SM66|1|1: field.SM66.option.Not_at_all
+              SM66|2|1: field.SM66.option.Several_days
+              SM66|3|1: field.SM66.option.More_than_half_the_days
+              SM66|4|1: field.SM66.option.Nearly_every_day
+          - field: SM67
+            shortLabel: field.SM67.label.Feeling_afraid_as_if_something
+            span: 24
+            type: radio-button
+            options:
+              SM67|1|1: field.SM67.option.Not_at_all
+              SM67|2|1: field.SM67.option.Several_days
+              SM67|3|1: field.SM67.option.More_than_half_the_days
+              SM67|4|1: field.SM67.option.Nearly_every_day
+  - section: section.Physical_Activity
+    fields:
+      - field: PA01
+        shortLabel: field.PA01.label.The_following_questions_concern
+        span: 24
+        type: label
+        standalone: true
+      - group: group.Work_and_Daily_Activities
+        span: 24
+        fields:
+          - field: PA05
+            shortLabel: field.PA05.label.Generally_speaking_would_you
+            span: 24
+            type: radio-button
+            options:
+              PA05|1|1: field.PA05.option.Very_inactive
+              PA05|2|1: field.PA05.option.Moderately_active
+              PA05|3|1: field.PA05.option.Active
+              PA05|4|1: field.PA05.option.Very_active
+      - group: group.Commuting_and_Transport
+        span: 24
+        fields:
+          - field: PA08
+            shortLabel: field.PA08.label.In_a_typical_week_how_many_days
+            span: 24
+            type: radio-button
+            options:
+              PA08|1|1: field.PA08.option.0_days
+              PA08|2|1: field.PA08.option.1_to_2_days
+              PA08|3|1: field.PA08.option.3_to_4_days
+              PA08|4|1: field.PA08.option.5_days_or_more
+          - field: PA09
+            shortLabel: field.PA09.label.Do_you_regularly_engage_in_a
+            span: 24
+            type: radio-button
+            options:
+              PA09|1|1: field.PA09.option.No
+              PA09|2|1: field.PA09.option.Yes_occasionally
+              PA09|3|1: field.PA09.option.Yes_1_to_2_times_per_week
+              PA09|4|1: field.PA09.option.Yes_3_times_per_week_or_more
+          - field: PA10
+            shortLabel: field.PA10.label.In_a_typical_week_how_many_days
+            span: 24
+            type: radio-button
+            options:
+              PA10|1|1: field.PA10.option.0_days
+              PA10|2|1: field.PA10.option.1_day
+              PA10|3|1: field.PA10.option.2_days
+              PA10|4|1: field.PA10.option.3_days_or_more
+          - field: PA11
+            shortLabel: field.PA11.label.On_a_typical_day_how_much_time
+            span: 24
+            type: radio-button
+            options:
+              PA11|1|1: field.PA11.option.Less_than_6_hours_per_day
+              PA11|2|1: field.PA11.option.6_to_8_hours_per_day
+              PA11|3|1: field.PA11.option.8_to_10_hours_per_day
+              PA11|4|1: field.PA11.option.More_than_10_hours_per_day
+          - field: PA12
+            shortLabel: field.PA12.label.Is_your_work_physically
+            span: 24
+            type: radio-button
+            options:
+              PA12|1|1: field.PA12.option.No_mainly_seated_or_standing
+              PA12|2|1: field.PA12.option.Yes_moderately_active_walking
+              PA12|3|1: field.PA12.option.Yes_physically_demanding
+  - section: section.Nutritional_Habits
+    fields:
+      - field: NH01
+        shortLabel: field.NH01.label.How_often_do_you_eat_fruit
+        span: 24
+        type: radio-button
+        options:
+          NH01|1|1: field.NH01.option.Every_day
+          NH01|2|1: field.NH01.option.4_to_6_times_per_week
+          NH01|3|1: field.NH01.option.1_to_3_times_per_week
+          NH01|4|1: field.NH01.option.Less_than_once_a_week
+          NH01|5|1: field.NH01.option.Never
+      - field: NH02
+        shortLabel: field.NH02.label.How_often_do_you_eat_vegetables
+        span: 24
+        type: radio-button
+        options:
+          NH01|1|1: field.NH02.option.Every_day
+          NH01|2|1: field.NH02.option.4_to_6_times_per_week
+          NH01|3|1: field.NH02.option.1_to_3_times_per_week
+          NH01|4|1: field.NH02.option.Less_than_once_a_week
+          NH01|5|1: field.NH02.option.Never
+      - field: NH03
+        shortLabel: field.NH03.label.How_often_do_you_drink_sugary
+        span: 24
+        type: radio-button
+        options:
+          NH03|1|1: field.NH03.option.Every_day
+          NH03|2|1: field.NH03.option.4_to_6_times_per_week
+          NH03|3|1: field.NH03.option.1_to_3_times_per_week
+          NH03|4|1: field.NH03.option.Less_than_once_a_week
+          NH03|5|1: field.NH03.option.Never
+      - field: NH04
+        shortLabel: field.NH04.label.How_often_do_you_eat_sweet_or
+        span: 24
+        type: radio-button
+        options:
+          NH03|1|1: field.NH04.option.Every_day
+          NH03|2|1: field.NH04.option.4_to_6_times_per_week
+          NH04|3|1: field.NH04.option.1_to_3_times_per_week
+          NH04|4|1: field.NH04.option.Less_than_once_a_week
+          NH04|5|1: field.NH04.option.Never
+      - field: NH05
+        shortLabel: field.NH05.label.On_average_how_much_water_do
+        span: 24
+        type: radio-button
+        options:
+          NH05|1|1: field.NH05.option.Less_than_1_litre
+          NH05|2|1: field.NH05.option.About_1_to_1.5_litres
+          NH05|3|1: field.NH05.option.More_than_1.5_litres
+          NH05|4|1: field.NH05.option.I_don_t_know
+      - field: NH06
+        shortLabel: field.NH06.label.How_often_do_you_eat_breakfast
+        span: 24
+        type: radio-button
+        options:
+          NH06|1|1: field.NH06.option.Every_day
+          NH06|2|1: field.NH06.option.5_to_6_times_per_week
+          NH06|3|1: field.NH06.option.2_to_4_times_per_week
+          NH06|4|1: field.NH06.option.Rarely
+          NH06|5|1: field.NH06.option.Never
+      - field: NH07
+        shortLabel: field.NH07.label.Do_you_snack_between_meals
+        span: 24
+        type: radio-button
+        options:
+          NH07|1|1: field.NH07.option.Yes_often
+          NH07|2|1: field.NH07.option.Yes_sometimes
+          NH07|3|1: field.NH07.option.No_rarely
+          NH07|4|1: field.NH07.option.No_never
+      - field: NH08
+        shortLabel: field.NH08.label.How_often_do_you_eat_processed
+        span: 24
+        type: radio-button
+        options:
+          NH08|1|1: field.NH08.option.Very_often
+          NH08|2|1: field.NH08.option.Often
+          NH08|3|1: field.NH08.option.Occasionally
+          NH08|4|1: field.NH08.option.Rarely
+          NH08|5|1: field.NH08.option.Never
+      - field: NH09
+        shortLabel: field.NH09.label.How_often_do_you_eat_fast_food
+        span: 24
+        type: radio-button
+        options:
+          NH09|1|1: field.NH09.option.Several_times_per_week
+          NH09|2|1: field.NH09.option.About_once_a_week
+          NH09|3|1: field.NH09.option.1_to_3_times_per_month
+          NH09|4|1: field.NH09.option.Rarely
+          NH09|5|1: field.NH09.option.Never
+      - field: NH16
+        shortLabel: field.NH16.label.Do_you_have_any_food
+        span: 24
+        type: text-field
+      - field: NH17
+        shortLabel: field.NH17.label.Which_foods_are_you_intolerant
+        span: 24
+        type: checkbox
+        options:
+          NH17|1|1: field.NH17.option.Milk_lactose
+          NH17|2|1: field.NH17.option.Peanuts
+          NH17|3|1: field.NH17.option.Walnuts
+          NH17|4|1: field.NH17.option.Hazelnuts
+          NH17|5|1: field.NH17.option.Other_nuts
+          NH17|6|1: field.NH17.option.Shellfish
+          NH17|7|1: field.NH17.option.Soy
+          NH17|8|1: field.NH17.option.Gluten_containing_cereals
+          NH17|9|1: field.NH17.option.Eggs
+          NH17|10|1: field.NH17.option.Fish
+          NH17|11|1: field.NH17.option.Other_specify
+      - field: NH18
+        shortLabel: field.NH18.label.Other_allergy_specify
+        span: 24
+        type: text-field
+        computedProperties:
+          hidden: return !hasOption(NH17[0],'11')
+      - field: NH19
+        shortLabel: field.NH19.label.Has_this_milk_lactose
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(NH17[0],'1')
+        options:
+          NH19|1|1: field.NH19.option.Yes
+          NH19|2|1: field.NH19.option.No
+          NH19|3|1: field.NH19.option.Don_t_know
+      - field: NH20
+        shortLabel: field.NH20.label.Has_this_peanut_intolerance_or
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(NH17[0],'2')
+        options:
+          NH20|1|1: field.NH20.option.Yes
+          NH20|2|1: field.NH20.option.No
+          NH20|3|1: field.NH20.option.Don_t_know
+      - field: NH21
+        shortLabel: field.NH21.label.Has_this_nut_intolerance_or
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return (!hasOption(NH17[0],'3') && !hasOption(NH17[0],'4') && !hasOption(NH17[0],'5'))
+        options:
+          NH21|1|1: field.NH21.option.Yes
+          NH21|2|1: field.NH21.option.No
+          NH21|3|1: field.NH21.option.Don_t_know
+      - field: NH22
+        shortLabel: field.NH22.label.Has_this_shellfish_intolerance
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(NH17[0],'6')
+        options:
+          NH22|1|1: field.NH22.option.Yes
+          NH22|2|1: field.NH22.option.No
+          NH22|3|1: field.NH22.option.Don_t_know
+      - field: NH23
+        shortLabel: field.NH23.label.Has_this_soy_intolerance_or
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(NH17[0],'7')
+        options:
+          NH23|1|1: field.NH23.option.Yes
+          NH23|2|1: field.NH23.option.No
+          NH23|3|1: field.NH23.option.Don_t_know
+      - field: NH24
+        shortLabel: field.NH24.label.Has_this_gluten_intolerance_or
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(NH17[0],'8')
+        options:
+          NH24|1|1: field.NH24.option.Yes
+          NH24|2|1: field.NH24.option.No
+          NH24|3|1: field.NH24.option.Don_t_know
+      - field: NH25
+        shortLabel: field.NH25.label.Has_this_egg_intolerance_or
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(NH17[0],'9')
+        options:
+          NH25|1|1: field.NH25.option.Yes
+          NH25|2|1: field.NH25.option.No
+          NH25|3|1: field.NH25.option.Don_t_know
+      - field: NH26
+        shortLabel: field.NH26.label.Has_this_fish_intolerance_or
+        span: 24
+        type: radio-button
+        computedProperties:
+          hidden: return !hasOption(NH17[0],'10')
+        options:
+          NH26|1|1: field.NH26.option.Yes
+          NH26|2|1: field.NH26.option.No
+          NH26|3|1: field.NH26.option.Don_t_know
+      - field: NH27
+        shortLabel: field.NH27.label.Has_another_intolerance_or
+        span: 24
+        type: text-field
+  - section: section.Sleep_Quality
+    fields:
+      - field: CD01
+        shortLabel: field.CD01.label.This_questionnaire_assesses_the
+        span: 24
+        type: label
+      - field: CD02
+        shortLabel: field.CD02.label.Do_you_have_trouble_falling
+        span: 24
+        type: radio-button
+        options:
+          CD02|1|1: field.CD02.option.Never
+          CD02|2|1: field.CD02.option.Rarely
+          CD02|3|1: field.CD02.option.Occasionally
+          CD02|4|1: field.CD02.option.Most_of_the_time
+          CD02|5|1: field.CD02.option.Always
+      - field: CD03
+        shortLabel: field.CD03.label.Do_you_have_trouble_staying
+        span: 24
+        type: radio-button
+        options:
+          CD03|1|1: field.CD03.option.Never
+          CD03|2|1: field.CD03.option.Rarely
+          CD03|3|1: field.CD03.option.Occasionally
+          CD03|4|1: field.CD03.option.Most_of_the_time
+          CD03|5|1: field.CD03.option.Always
+      - field: CD04
+        shortLabel: field.CD04.label.Do_you_take_medication_to_help
+        span: 24
+        type: radio-button
+        options:
+          CD04|1|1: field.CD04.option.Never
+          CD04|2|1: field.CD04.option.Rarely
+          CD04|3|1: field.CD04.option.Occasionally
+          CD04|4|1: field.CD04.option.Most_of_the_time
+          CD04|5|1: field.CD04.option.Always
+      - field: CD05
+        shortLabel: field.CD05.label.Do_you_drink_alcohol_to_help
+        span: 24
+        type: radio-button
+        options:
+          CD05|1|1: field.CD05.option.Never
+          CD05|2|1: field.CD05.option.Rarely
+          CD05|3|1: field.CD05.option.Occasionally
+          CD05|4|1: field.CD05.option.Most_of_the_time
+          CD05|5|1: field.CD05.option.Always
+      - field: CD06
+        shortLabel: field.CD06.label.Is_there_a_health_problem_that
+        span: 24
+        type: radio-button
+        options:
+          CD06|1|1: field.CD06.option.Never
+          CD06|2|1: field.CD06.option.Rarely
+          CD06|3|1: field.CD06.option.Occasionally
+          CD06|4|1: field.CD06.option.Most_of_the_time
+          CD06|5|1: field.CD06.option.Always
+      - field: CD07
+        shortLabel: field.CD07.label.Have_you_lost_all_interest_in
+        span: 24
+        type: radio-button
+        options:
+          CD07|1|1: field.CD07.option.Never
+          CD07|2|1: field.CD07.option.Rarely
+          CD07|3|1: field.CD07.option.Occasionally
+          CD07|4|1: field.CD07.option.Most_of_the_time
+          CD07|5|1: field.CD07.option.Always
+      - field: CD08
+        shortLabel: field.CD08.label.Do_you_feel_sad_irritable_or
+        span: 24
+        type: radio-button
+        options:
+          CD08|1|1: field.CD08.option.Never
+          CD08|2|1: field.CD08.option.Rarely
+          CD08|3|1: field.CD08.option.Occasionally
+          CD08|4|1: field.CD08.option.Most_of_the_time
+          CD08|5|1: field.CD08.option.Always
+      - field: CD09
+        shortLabel: field.CD09.label.Do_you_feel_nervous_or_anxious
+        span: 24
+        type: radio-button
+        options:
+          CD09|1|1: field.CD09.option.Never
+          CD09|2|1: field.CD09.option.Rarely
+          CD09|3|1: field.CD09.option.Occasionally
+          CD09|4|1: field.CD09.option.Most_of_the_time
+          CD09|5|1: field.CD09.option.Always
+      - field: CD10
+        shortLabel: field.CD10.label.Do_you_think_there_is_something
+        span: 24
+        type: radio-button
+        options:
+          CD10|1|1: field.CD10.option.Never
+          CD10|2|1: field.CD10.option.Rarely
+          CD10|3|1: field.CD10.option.Occasionally
+          CD10|4|1: field.CD10.option.Most_of_the_time
+          CD10|5|1: field.CD10.option.Always
+      - field: CD11
+        shortLabel: field.CD11.label.Is_your_work_schedule_variable
+        span: 24
+        type: radio-button
+        options:
+          CD11|1|1: field.CD11.option.Never
+          CD11|2|1: field.CD11.option.Rarely
+          CD11|3|1: field.CD11.option.Occasionally
+          CD11|4|1: field.CD11.option.Most_of_the_time
+          CD11|5|1: field.CD11.option.Always
+      - field: CD12
+        shortLabel: field.CD12.label.Are_your_legs_restless_and_or
+        span: 24
+        type: radio-button
+        options:
+          CD12|1|1: field.CD12.option.Never
+          CD12|2|1: field.CD12.option.Rarely
+          CD12|3|1: field.CD12.option.Occasionally
+          CD12|4|1: field.CD12.option.Most_of_the_time
+          CD12|5|1: field.CD12.option.Always
+      - field: CD13
+        shortLabel: field.CD13.label.Have_you_been_told_that_you_are
+        span: 24
+        type: radio-button
+        options:
+          CD13|1|1: field.CD13.option.Never
+          CD13|2|1: field.CD13.option.Rarely
+          CD13|3|1: field.CD13.option.Occasionally
+          CD13|4|1: field.CD13.option.Most_of_the_time
+          CD13|5|1: field.CD13.option.Always
+      - field: CD14
+        shortLabel: field.CD14.label.Do_you_have_unusual_behaviours
+        span: 24
+        type: radio-button
+        options:
+          CD14|1|1: field.CD14.option.Never
+          CD14|2|1: field.CD14.option.Rarely
+          CD14|3|1: field.CD14.option.Occasionally
+          CD14|4|1: field.CD14.option.Most_of_the_time
+          CD14|5|1: field.CD14.option.Always
+      - field: CD15
+        shortLabel: field.CD15.label.Do_you_snore
+        span: 24
+        type: radio-button
+        options:
+          CD15|1|1: field.CD15.option.Never
+          CD15|2|1: field.CD15.option.Rarely
+          CD15|3|1: field.CD15.option.Occasionally
+          CD15|4|1: field.CD15.option.Most_of_the_time
+          CD15|5|1: field.CD15.option.Always
+      - field: CD16
+        shortLabel: field.CD16.label.Have_you_been_told_that_you
+        span: 24
+        type: radio-button
+        options:
+          CD16|1|1: field.CD16.option.Never
+          CD16|2|1: field.CD16.option.Rarely
+          CD16|3|1: field.CD16.option.Occasionally
+          CD16|4|1: field.CD16.option.Most_of_the_time
+          CD16|5|1: field.CD16.option.Always
+      - field: CD17
+        shortLabel: field.CD17.label.Do_you_have_trouble_staying
+        span: 24
+        type: radio-button
+        options:
+          CD17|1|1: field.CD17.option.Never
+          CD17|2|1: field.CD17.option.Rarely
+          CD17|3|1: field.CD17.option.Occasionally
+          CD17|4|1: field.CD17.option.Most_of_the_time
+          CD17|5|1: field.CD17.option.Always
+      - field: CD18
+        shortLabel: field.CD18.label.Total_score
+        span: 24
+        type: number-field
+        styleOptions:
+          decimalPlaces: 0
+        computedProperties:
+          value: |
+            return { content: { '*': { 
+              type: 'number', 
+              value: (score(CD02[0])+score(CD03[0])+score(CD04[0])+score(CD05[0])+score(CD06[0])+score(CD07[0])+score(CD08[0])+score(CD09[0])+score(CD10[0])+score(CD11[0])+score(CD12[0])+score(CD13[0])+score(CD14[0])+score(CD15[0])+score(CD16[0])+score(CD17[0])) 
+            } }, codes: [] }
+      - group: group.Note_to_physician._Help_with
+        span: 24
+        fields:
+          - field: CD20
+            shortLabel: field.CD20.label.SO1_15_Insomnia
+            span: 24
+            type: label
+          - field: CD21
+            shortLabel: field.CD21.label.With_a_score_of_3_4_or_5_on_any
+            span: 24
+            type: label
+          - field: CD22
+            shortLabel: field.CD22.label.SO6_9_Mental_health_disorders
+            span: 24
+            type: label
+          - field: CD23
+            shortLabel: field.CD23.label.Scores_of_4_or_5_on_questions_6
+            span: 24
+            type: label
+          - field: CD24
+            shortLabel: field.CD24.label.SO10_Circadian_rhythm_disorders
+            span: 24
+            type: label
+          - field: CD25
+            shortLabel: field.CD25.label.A_score_of_4_or_5_on_question
+            span: 24
+            type: label
+          - field: CD26
+            shortLabel: field.CD26.label.SO11_12_Restless_legs_syndrome
+            span: 24
+            type: label
+          - field: CD27
+            shortLabel: field.CD27.label.A_score_of_4_or_5_on_question
+            span: 24
+            type: label
+          - field: CD28
+            shortLabel: field.CD28.label.SO13_Parasomnias
+            span: 24
+            type: label
+          - field: CD29
+            shortLabel: field.CD29.label.A_score_of_2_to_5_on_question
+            span: 24
+            type: label
+          - field: CD30
+            shortLabel: field.CD30.label.SO14_16_Sleep_apnoea
+            span: 24
+            type: label
+          - field: CD31
+            shortLabel: field.CD31.label.A_score_of_4_or_5_on_question
+            span: 24
+            type: label
+  - section: section.Dependencies
+    fields:
+      - group: group.Tobacco
+        span: 24
+        fields:
+          - field: DEP01
+            shortLabel: field.DEP01.label.Describe_your_smoking_behaviour
+            span: 24
+            type: radio-button
+            options:
+              DEP01|1|1: field.DEP01.option.I_have_never_smoked
+              DEP01|2|1: field.DEP01.option.I_used_to_smoke_but_I_have_quit
+              DEP01|3|1: field.DEP01.option.I_smoke
+          - field: DEP11
+            shortLabel: field.DEP11.label.How_many_years_ago_did_you_quit
+            span: 24
+            type: text-field
+            computedProperties:
+              hidden: return !hasOption(DEP01[0],'2')
+          - field: DEP02
+            shortLabel: field.DEP02.label.Amount_consumed
+            span: 24
+            type: text-field
+          - field: DEP03
+            shortLabel: field.DEP03.label.Duration_of_consumption_in_years
+            span: 24
+            type: text-field
+      - group: group.Alcohol
+        span: 24
+        fields:
+          - field: DEP04
+            shortLabel: field.DEP04.label.Describe_your_alcohol
+            span: 24
+            type: radio-button
+            options:
+              DEP01|1|1: field.DEP04.option.I_drink_alcohol
+              DEP01|2|1: field.DEP04.option.I_have_never_consumed_alcohol
+              DEP01|3|1: field.DEP04.option.I_used_to_drink_alcohol_but_I
+          - field: DEP12
+            shortLabel: field.DEP12.label.How_many_years_ago_did_you_stop
+            span: 24
+            type: text-field
+            computedProperties:
+              hidden: return !hasOption(DEP04[0],'3')
+          - field: DEP05
+            shortLabel: field.DEP05.label.Amount_consumed
+            span: 24
+            type: text-field
+          - field: DEP06
+            shortLabel: field.DEP06.label.Duration_of_consumption_in_years
+            span: 24
+            type: text-field
+  - section: section.General_Practitioner
+    fields:
+      - field: GP01
+        shortLabel: field.GP01.label.Contact_with_a_general
+        span: 24
+        type: label
+      - field: GP02
+        shortLabel: field.GP02.label.Here_are_some_questions_about
+        span: 24
+        type: label
+      - field: GP03
+        shortLabel: field.GP03.label.Do_you_have_a_regular_general
+        span: 24
+        type: radio-button
+        options:
+          GP03|1|1: field.GP03.option.Yes
+          GP03|2|1: field.GP03.option.No
+          GP03|3|1: field.GP03.option.Don_t_know
+      - field: GP04
+        shortLabel: field.GP04.label.The_following_questions_concern
+        span: 24
+        type: label
+        standalone: true
+      - field: GP05
+        shortLabel: field.GP05.label.When_did_you_last_see_a_general
+        span: 24
+        type: radio-button
+        options:
+          GP05|1|1: field.GP05.option.Less_than_6_months_ago
+          GP05|2|1: field.GP05.option.More_than_6_months_ago
+          GP05|3|1: field.GP05.option.Never
+          GP05|4|1: field.GP05.option.Don_t_know
+translations:
+  - language: fr
+    translations:
+      section.Summary: Résumé
+      group.Patient_Data: Données patient
+      field.DP1.label.Name: Nom
+      field.DP2.label.Gender: Sexe
+      field.DP3.label.Date_of_Birth: Date de naissance
+      field.GI01.label.Weight_kg: Poids, kg
+      field.GI02.label.Height_cm: Taille, cm
+      field.GI03.label.BMI_kg_m2: BMI, kg/m2
+      field.GI04.label.Waist_circumference_cm: Tour de taille, cm
+      field.GI08.label.Blood_type: Groupe sanguin
+      field.GI05.label.SBP_mmHg: TA sys., mmHg
+      field.GI06.label.DBP_mmHg: TA dia., mmHg
+      field.GI07.label.HR_bpm: Fréq. card., bpm
+      field.GI10.label.HDL_mmol_l: HDL, mmol/l
+      field.GI11.label.CV_Score: CV Score
+      group.Medical_Summary: Résumé médical
+      field.RM1.label.Chronic_treatments: Traitements chroniques
+      field.RM2.label.Allergies: Allergies
+      field.RM3.label.Medical_history: Antécédents médicaux
+      field.RM4.label.Surgical_history: Antécédents chirurgicaux
+      field.RM5.label.Family_history: Antécédents familiaux
+      group.Recommendations: Recommandations
+      field.RE01.label.General_health_status: État général de santé
+      field.RE02.label.Social_and_environmental_context: Context social et environnemental
+      field.RE03.label.Mental_health: Santé mentale
+      field.RE03B.label.Sleep_quality: Qualité du sommeil
+      field.RE04.label.Nutrition_and_physical_activity: Alimentation et activité physique
+      field.RE05.label.Alcohol_consumption_and: Consommation d'alcool et addictions
+      field.RE06.label.Quality_and_life_expectancy: Qualité et espérance de vie
+      field.RE07.label.Health_journey: Parcours santé
+      field.RE08.label.Blood_test_results: Résultats de la prise de sang
+      field.RE09.label.Conclusion._Key_recommendations: Conclusion. Recommandations principales
+      section.General_Information: Informations générales
+      field.GI01.label.Weight_kg_2: Poids, kg
+      field.GI02.label.Height_cm_2: Taille, cm
+      field.GI03.label.BMI_kg_m2_2: BMI, kg/m2
+      field.GI04.label.Waist_circumference_cm_2: Tour de taille, cm
+      field.GI05.label.Blood_pressure_systolic_mmHg: Tension artérielle (systolique), mmHg
+      field.GI06.label.Blood_pressure_diastolic_mmHg: Tension artérielle (diastolique), mmHg
+      field.GI07.label.Heart_rate_bpm: Fréquence cardiaque, bpm
+      field.GI08.label.Blood_type_2: Groupe sanguin
+      field.GI09.label.How_many_children_do_you_have: Combien d'enfants avez-vous
+      field.MS1.label.STD_screening: Bilan MST
+      field.CP1.label.Patient_comment: Commentaire patient
+      section.Caregiver: Aidant proche
+      field.IC01.label.Do_you_at_least_once_a_week: Apportez-vous, au moins une fois par semaine, en dehors de votre profession, de l'aide ou des soins à une ou plusieurs personnes ayant des problèmes liés à l'âge, une maladie chronique, une affection de longue durée ou un handicap?
+      field.IC01.option.Yes: Oui
+      field.IC01.option.No: Non
+      field.IC02.label.Outside_your_profession_to_whom: En dehors de votre profession, a qui apportez-vous le plus d'aide ou de soins ? (une seule réponse possible)
+      field.IC02.option.One_or_more_household_member_s: Un ou plusieurs membre(s) du ménage
+      field.IC02.option.One_or_more_family_member_s_but: Un ou plusieurs membre(s) de la famille mais non-membre(s) du ménage
+      field.IC02.option.One_or_more_persons_not: Une ou plusieurs personnes, non-membre(s) du ménage ou de la famille
+      field.IC03.label.In_total_how_many_hours_per: Au total, combien d'heures  par semaine consacrez-vous généralement à apporter de l'aide ou des soins?
+      field.IC03.option.Less_than_10_hours_per_week: Moins que 10 heures par semaine
+      field.IC03.option.At_least_10_hours_but_less_than: Au moins 10 heures, mais moins que 20 heures par semaine
+      field.IC03.option.20_hours_per_week_or_more: 20 heures par semaine ou plus
+      section.Social_Life: Vie sociale
+      field.SO01.label.How_would_you_overall_describe: Comment qualifieriez-vous globalement vos contacts sociaux (famille, amis, entourage) ?
+      field.SO01.option.Very_satisfying: Très satisfaisants
+      field.SO01.option.Rather_satisfying: Plutôt satisfaisants
+      field.SO01.option.Rather_unsatisfying: Plutôt insatisfaisants
+      field.SO01.option.Really_unsatisfying: Vraiment insatisfaisants
+      field.SO03.label.How_many_people_are_close: Combien de personnes sont suffisamment proches de vous pour que vous puissiez compter sur elles en cas de difficultés importantes ?
+      field.SO03.option.None: Aucune
+      field.SO03.option.1_or_2: 1 ou 2
+      field.SO03.option.3_to_5: 3 à 5
+      field.SO03.option.6_or_more: 6 ou plus
+      section.Environmental_Factors: Facteurs environnementaux
+      field.HE01.label.I_will_now_ask_you_2_sets_of: Je vais maintenant vous poser 2 séries de questions qui concernent les facteurs environnementaux. La première série concerne les facteurs environnementaux dans votre quartier, alors que la seconde concerne les facteurs qui peuvent vous affecter, chez vous, à la maison.
+      group.Series_1_Neighbourhood: "Série 1: Quartier"
+      field.HE03.label.In_your_neighbourhood_to_what: Dans votre quartier ou voisinage, à quel point les conditions suivantes posent-elles un problème?
+      field.HE04.label.Is_traffic_speed_or_volume_a: La vitesse ou le volume du trafic pose-t-elle problème ?
+      field.HE04.option.Not_a_problem_at_all: Pas du tout un problème
+      field.HE04.option.Minor_problem: Problème mineur
+      field.HE04.option.Fairly_big_problem: Assez gros problème
+      field.HE04.option.Very_big_problem: Très gros problème
+      field.HE04.option.Don_t_know: Ne sais pas
+      field.HE04.option.No_answer: Pas de réponse
+      field.HE07.label.Does_lack_of_access_to_parks_or: Manque d'accès à des parcs ou d'autres espaces publics verts ou récréatifs pose-t-il problème ?
+      field.HE07.option.Not_a_problem_at_all: Pas du tout un problème
+      field.HE07.option.Minor_problem: Problème mineur
+      field.HE07.option.Fairly_big_problem: Assez gros problème
+      field.HE07.option.Very_big_problem: Très gros problème
+      field.HE07.option.Don_t_know: Ne sait pas
+      field.HE07.option.No_answer: Pas de réponse
+      group.Series_2_Home: "Série 2: Maison"
+      field.HE09.label.Thinking_about_the_last_12: Si vous pensez aux 12 derniers mois, quand vous êtes à domicile, de quelle façon êtes-vous gêné(e), affecté(e) ou ennuyé(e), par les conditions suivantes?
+      field.HE10.label.Does_air_pollution_pose_a: Pollution de l’air pose-t-elle problème ?
+      field.HE10.option.Not_at_all: Pas du tout
+      field.HE10.option.Slightly: Légèrement
+      field.HE10.option.Moderately: Moyennement
+      field.HE10.option.A_lot: Beaucoup
+      field.HE10.option.Extremely: Extrêmement
+      field.HE10.option.Don_t_know: Ne sait pas
+      field.HE10.option.No_answer: Pas de réponse
+      field.HE13.label.Is_traffic_noise_a_problem_road: Bruit du trafic routier pose-t-il problème ? (route, train, tram, métro, avion)
+      field.HE13.option.Not_at_all: Pas du tout
+      field.HE13.option.Slightly: Légèrement
+      field.HE13.option.Moderately: Moyennement
+      field.HE13.option.A_lot: Beaucoup
+      field.HE13.option.Extremely: Extrêmement
+      field.HE13.option.Don_t_know: Ne sait pas
+      field.HE13.option.No_answer: Pas de réponse
+      field.HE16.label.Does_noise_from_nearby: Bruit provenant des entreprises proches (usine, atelier) pose-t-il problème ?
+      field.HE16.option.Not_at_all: Pas du tout
+      field.HE16.option.Slightly: Légèrement
+      field.HE16.option.Moderately: Moyennement
+      field.HE16.option.A_lot: Beaucoup
+      field.HE16.option.Extremely: Extrêmement
+      field.HE16.option.Don_t_know: Ne sait pas
+      field.HE16.option.No_answer: Pas de réponse
+      section.Work_Absence: Absence au travail
+      field.AW01.label.In_the_past_12_months_were_you: Au cours des 12 derniers mois, avez-vous été absent(e) de votre travail pour des raisons de santé? (toutes maladies, blessures ou problèmes de santé ayant entraîné une absence)
+      field.AW01.option.Yes: Oui
+      field.AW01.option.No: Non
+      field.AW02.label.In_the_past_12_months_how_many: Au cours des 12 derniers mois, combien de jours au total étiez-vous absent(e) de votre travail pour des raisons de santé? Si vous ne connaissez pas le nombre exact de jours, donnez une estimation.
+      field.AW03.label.What_is_the_main_reason_for: Quel est la raison principale de cette absence ?
+      field.AW03.option.Physical_health_problem: Problème de santé physique
+      field.AW03.option.Fatigue_stress_or_burnout: Fatigue, stress ou épuisement
+      field.AW03.option.Accident_or_injury: Accident ou blessure
+      field.AW03.option.Other_reason: Autre raison
+      field.AW03.option.I_prefer_not_to_answer: Je préfère ne pas répondre
+      section.Medical_History: Antécédents
+      group.Cardiovascular_history: Antécédents cardiovasculaires
+      field.CV00.label.The_following_questions_concern: Les questions suivantes concernent votre santé cardiovasculaire (cœur et vaisseaux).
+      field.CV01.label.Has_a_doctor_ever_diagnosed_you: Un médecin vous a-t-il déjà diagnostiqué une ou plusieurs des maladies suivantes ? (Plusieurs réponses possibles)
+      field.CV01.option.High_blood_pressure: Hypertension artérielle
+      field.CV01.option.Coronary_artery_disease_angina: Maladie coronarienne / angine de poitrine
+      field.CV01.option.Myocardial_infarction: Infarctus du myocarde
+      field.CV01.option.Heart_rhythm_disorder_e.g.: Trouble du rythme cardiaque (ex. fibrillation auriculaire)
+      field.CV01.option.Heart_failure: Insuffisance cardiaque
+      field.CV01.option.Stroke_CVA_or_TIA: Accident vasculaire cérébral (AVC) ou AIT
+      field.CV01.option.Peripheral_artery_disease: Artérite des membres inférieurs
+      field.CV01.option.Other_cardiovascular_disease: Autre maladie cardiovasculaire
+      field.CV01.option.None: Aucune
+      field.CV01.option.I_don_t_know: Je ne sais pas
+      field.CV02.label.Are_you_currently_taking: Prenez-vous actuellement un traitement pour le cœur ou la tension artérielle ?
+      field.CV02.option.Yes: Oui
+      field.CV02.option.No: Non
+      field.CV02.option.I_don_t_know: Je ne sais pas
+      field.CV03.label.In_recent_months_have_you: Au cours des derniers mois, avez-vous ressenti régulièrement l'un ou plusieurs des symptômes suivants ? (Plusieurs réponses possibles)
+      field.CV03.option.Unusual_shortness_of_breath_on: Essoufflement inhabituel à l'effort
+      field.CV03.option.Chest_pain_or_tightness: Douleur ou oppression thoracique
+      field.CV03.option.Palpitations_or_irregular: Palpitations ou rythme cardiaque irrégulier
+      field.CV03.option.Dizziness_faintness_or_loss_of: Étourdissement, malaise ou perte de connaissance
+      field.CV03.option.Swelling_of_ankles_or_legs: Gonflement des chevilles ou des jambes
+      field.CV03.option.None_of_these_symptoms: Aucun de ces symptômes
+      field.CV04.label.Are_you_currently_being: Êtes-vous actuellement suivi(e) par un médecin pour votre cœur ou votre tension artérielle ?
+      field.CV04.option.Yes: Oui
+      field.CV04.option.No: Non
+      field.CV04.option.I_don_t_know: Je ne sais pas
+      group.Metabolic_Endocrine_history: Antécédents métaboliques / Endocriniens
+      field.EN00.label.The_following_questions_concern: Les questions suivantes concernent votre métabolisme (sucre, cholestérol, hormones).
+      field.EN01.label.Has_a_doctor_ever_diagnosed_you: Un médecin vous a-t-il déjà diagnostiqué une ou plusieurs des maladies suivantes ? (Plusieurs réponses possibles)
+      field.EN01.option.Type_2_diabetes: Diabète de type 2
+      field.EN01.option.Type_1_diabetes: Diabète de type 1
+      field.EN01.option.Prediabetes_glucose_intolerance: Prédiabète / intolérance au glucose
+      field.EN01.option.High_cholesterol_dyslipidaemia: Cholestérol élevé (dyslipidémie)
+      field.EN01.option.Thyroid_disease_hypo_or: Maladie de la thyroïde (hypo- ou hyperthyroïdie)
+      field.EN01.option.Metabolic_syndrome: Syndrome métabolique
+      field.EN01.option.Other_metabolic_or_endocrine: Autre maladie métabolique ou endocrinienne
+      field.EN01.option.None: Aucune
+      field.EN01.option.I_don_t_know: Je ne sais pas
+      field.EN02.label.Are_you_currently_being: Êtes-vous actuellement suivi(e) par un médecin pour un problème lié au métabolisme (sucre, cholestérol, thyroïde, hormones) ?
+      field.EN02.option.Yes: Oui
+      field.EN02.option.No: Non
+      field.EN02.option.I_don_t_know: Je ne sais pas
+      group.Respiratory_history: Antécédents respiratoires
+      field.RS00.label.The_following_questions_concern: Les questions suivantes concernent votre santé respiratoire.
+      field.RS01.label.Have_you_ever_been_diagnosed_by: Avez-vous déjà été diagnostiqué(e) par un médecin pour une maladie respiratoire ?
+      field.RS01.option.Yes: Oui
+      field.RS01.option.No: Non
+      field.RS01.option.I_don_t_know_I_m_not_sure: Je ne sais pas / je ne suis pas sûr(e)
+      field.RS02.label.What_respiratory_diagnosis: Quel(s) diagnostic(s) respiratoire(s) vous a/ont été posé(s) par un médecin ? (Plusieurs réponses possibles)
+      field.RS02.option.Asthma_current: Asthme (actuel)
+      field.RS02.option.Childhood_past_asthma: Asthme dans l'enfance / ancien
+      field.RS02.option.Chronic_obstructive_pulmonary: "Broncho-pneumopathie chronique obstructive (BPCO : bronchite chronique et/ou emphysème)"
+      field.RS02.option.Recurrent_bronchitis: Bronchites à répétition
+      field.RS02.option.Pulmonary_fibrosis: Fibrose pulmonaire
+      field.RS02.option.Sarcoidosis: Sarcoïdose
+      field.RS02.option.Allergic_alveolitis: Alvéolite allergique
+      field.RS02.option.Cystic_fibrosis: Mucoviscidose
+      field.RS02.option.Other_diagnosed_respiratory: Autre maladie respiratoire diagnostiquée (préciser)
+      field.RS02.option.I_don_t_know_the_exact_diagnosis: Je ne connais pas le diagnostic exact
+      field.RS03.label.Are_you_currently_being_treated: Êtes-vous actuellement traité(e) pour un problème respiratoire ? (Plusieurs réponses possibles)
+      field.RS03.option.Inhaler_spray_e.g.: Inhalateur / spray (ex. bronchodilatateur, corticoïde inhalé)
+      field.RS03.option.Night_time_ventilation_CPAP: Ventilation nocturne (PPC / CPAP)
+      field.RS03.option.Home_oxygen_therapy: Oxygène à domicile
+      field.RS03.option.Other_respiratory_treatment: Autre traitement respiratoire
+      field.RS03.option.No_respiratory_treatment: Aucun traitement respiratoire
+      field.RS04.label.Do_you_currently_have_one_or: Présentez-vous actuellement un ou plusieurs des symptômes suivants ? (Plusieurs réponses possibles)
+      field.RS04.option.Shortness_of_breath_on_exertion: Essoufflement à l'effort ou au repos
+      field.RS04.option.Wheezing: Respiration sifflante
+      field.RS04.option.Chronic_cough: Toux chronique
+      field.RS04.option.Persistent_fatigue_possibly: Fatigue persistante possiblement liée à la respiration
+      field.RS04.option.Significant_snoring: Ronflements importants
+      field.RS04.option.No_respiratory_symptoms: Aucun symptôme respiratoire
+      group.Musculoskeletal_history: Antécédents musculo-squelettiques
+      field.MQ00.label.The_following_questions_concern: Les questions suivantes concernent votre système musculo-squelettique (dos, articulations, muscles, tendons).
+      field.MQ01.label.Has_a_doctor_ever_diagnosed_you: Un médecin vous a-t-il déjà diagnostiqué une ou plusieurs des affections suivantes ? (Plusieurs réponses possibles)
+      field.MQ01.option.Chronic_low_back_pain_herniated: Lombalgie chronique / hernie discale / sciatique
+      field.MQ01.option.Chronic_neck_pain: Cervicalgie chronique
+      field.MQ01.option.Osteoarthritis_hip_knee_spine: Arthrose (hanche, genou, colonne, autre)
+      field.MQ01.option.Chronic_tendinitis_shoulder: Tendinite chronique (épaule, coude, poignet, autre)
+      field.MQ01.option.Carpal_tunnel_syndrome: Syndrome du canal carpien
+      field.MQ01.option.Work_related_musculoskeletal: Trouble musculo-squelettique lié au travail (TMS reconnu)
+      field.MQ01.option.Other_musculoskeletal_condition: Autre affection musculo-squelettique
+      field.MQ01.option.None: Aucune
+      field.MQ01.option.I_don_t_know: Je ne sais pas
+      field.MQ02.label.Are_you_currently_being_treated: Êtes-vous actuellement suivi(e) pour un problème musculo-squelettique ? (médecin, kinésithérapeute, rhumatologue, ostéopathe, etc.)
+      field.MQ02.option.Yes: Oui
+      field.MQ02.option.No: Non
+      field.MQ02.option.I_don_t_know: Je ne sais pas
+      field.MQ03.label.In_recent_months_have_you: Au cours des derniers mois, avez-vous ressenti régulièrement l'un ou plusieurs des symptômes suivants ? (Plusieurs réponses possibles)
+      field.MQ03.option.Back_or_neck_pain: Douleurs du dos ou de la nuque
+      field.MQ03.option.Shoulder_arm_or_wrist_pain: Douleurs des épaules, bras ou poignets
+      field.MQ03.option.Hip_knee_or_ankle_pain: Douleurs des hanches, genoux ou chevilles
+      field.MQ03.option.Prolonged_joint_stiffness: Raideur articulaire prolongée
+      field.MQ03.option.Decreased_mobility_or_strength: Diminution de la mobilité ou de la force
+      field.MQ03.option.None_of_these_symptoms: Aucun de ces symptômes
+      field.MQ04.label.Do_these_pains_or_limitations: Ces douleurs ou limitations ont-elles un impact sur votre vie quotidienne ou votre travail ?
+      field.MQ04.option.Not_at_all: Pas du tout
+      field.MQ04.option.A_little: Un peu
+      field.MQ04.option.A_lot: Beaucoup
+      field.MQ04.option.Not_applicable_no_pain: Non applicable (pas de douleurs)
+      group.Neurological_history: Antécédents neurologiques
+      field.NE00.label.The_following_questions_concern: Les questions suivantes concernent votre système neurologique (cerveau, nerfs, équilibre).
+      field.NE01.label.Has_a_doctor_ever_diagnosed_you: Un médecin vous a-t-il déjà diagnostiqué une ou plusieurs des maladies suivantes ? (Plusieurs réponses possibles)
+      field.NE01.option.Chronic_migraine: Migraine chronique
+      field.NE01.option.Epilepsy: Épilepsie
+      field.NE01.option.Multiple_sclerosis: Sclérose en plaques
+      field.NE01.option.Parkinson_s_disease: Maladie de Parkinson
+      field.NE01.option.Peripheral_neuropathy_tingling: Neuropathie périphérique (fourmillements, perte de sensibilité…)
+      field.NE01.option.Neurological_disorder_following: Trouble neurologique suite à un AVC
+      field.NE01.option.Other_neurological_disease: Autre maladie neurologique
+      field.NE01.option.None: Aucune
+      field.NE01.option.I_don_t_know: Je ne sais pas
+      field.NE02.label.Are_you_currently_being: Êtes-vous actuellement suivi(e) par un médecin pour un problème neurologique ?
+      field.NE02.option.Yes: Oui
+      field.NE02.option.No: Non
+      field.NE02.option.I_don_t_know: Je ne sais pas
+      field.NE03.label.In_recent_months_have_you: Au cours des derniers mois, avez-vous ressenti régulièrement l'un ou plusieurs des symptômes suivants qui ne sont PAS expliqués par un diagnostic neurologique connu ? (Plusieurs réponses possibles)
+      field.NE03.option.Frequent_or_unusual_headaches: Maux de tête fréquents ou inhabituels
+      field.NE03.option.Dizziness_or_balance_problems: Vertiges ou troubles de l'équilibre
+      field.NE03.option.Numbness_tingling_or_loss_of: Engourdissements, fourmillements ou perte de sensibilité
+      field.NE03.option.Unexplained_muscle_weakness: Faiblesse musculaire inexpliquée
+      field.NE03.option.Concentration_or_memory_problems: Troubles de la concentration ou de la mémoire
+      field.NE03.option.Unusual_tremors: Tremblements inhabituels
+      field.NE03.option.None_of_these_symptoms: Aucun de ces symptômes
+      field.NE04.label.Do_these_symptoms_impact_your: Ces symptômes ont-ils un impact sur votre vie quotidienne ou votre travail ?
+      field.NE04.option.Not_at_all: Pas du tout
+      field.NE04.option.A_little: Un peu
+      field.NE04.option.A_lot: Beaucoup
+      field.NE04.option.Not_applicable_no_symptoms: Non applicable (aucun symptôme)
+      group.Digestive_hepatic_history: Antécédents digestifs / hépatiques
+      field.DG00.label.The_following_questions_concern: Les questions suivantes concernent votre système digestif et votre foie.
+      field.DG01.label.Has_a_doctor_ever_diagnosed_you: Un médecin vous a-t-il déjà diagnostiqué une ou plusieurs des maladies suivantes ? (Plusieurs réponses possibles)
+      field.DG01.option.Gastroesophageal_reflux_disease: Reflux gastro-œsophagien (RGO)
+      field.DG01.option.Stomach_or_duodenal_ulcer: Ulcère de l'estomac ou du duodénum
+      field.DG01.option.Irritable_bowel_syndrome_IBS: Syndrome de l'intestin irritable (SII)
+      field.DG01.option.Inflammatory_bowel_disease: Maladie inflammatoire chronique de l'intestin (Crohn, rectocolite hémorragique)
+      field.DG01.option.Liver_disease_fatty_liver: Maladie du foie (stéatose hépatique, hépatite chronique, cirrhose…)
+      field.DG01.option.Digestive_polyps_or_history_of: Polypes digestifs ou antécédent de cancer digestif
+      field.DG01.option.Other_digestive_or_liver_disease: Autre maladie digestive ou hépatique
+      field.DG01.option.None: Aucune
+      field.DG01.option.I_don_t_know: Je ne sais pas
+      field.DG02.label.Are_you_currently_being: Êtes-vous actuellement suivi(e) par un médecin pour un problème digestif ou hépatique ?
+      field.DG02.option.Yes: Oui
+      field.DG02.option.No: Non
+      field.DG02.option.I_don_t_know: Je ne sais pas
+      field.DG03.label.In_recent_months_have_you: Au cours des derniers mois, avez-vous ressenti régulièrement l'un ou plusieurs des symptômes suivants qui ne sont PAS expliqués par un diagnostic digestif connu ? (Plusieurs réponses possibles)
+      field.DG03.option.Heartburn_or_acid_reflux: Brûlures d'estomac ou remontées acides
+      field.DG03.option.Recurrent_abdominal_pain: Douleurs abdominales récurrentes
+      field.DG03.option.Significant_bloating_or: Ballonnements importants ou inconfort digestif fréquent
+      field.DG03.option.Bowel_irregularities_persistent: Troubles du transit (diarrhée ou constipation persistante)
+      field.DG03.option.Frequent_nausea: Nausées fréquentes
+      field.DG03.option.Unusual_stools_colour_appearance: Selles inhabituelles (couleur, aspect)
+      field.DG03.option.None_of_these_symptoms: Aucun de ces symptômes
+      field.DG04.label.Do_these_digestive_issues: Ces troubles digestifs ont-ils un impact sur votre vie quotidienne ou votre travail ?
+      field.DG04.option.Not_at_all: Pas du tout
+      field.DG04.option.A_little: Un peu
+      field.DG04.option.A_lot: Beaucoup
+      field.DG04.option.Not_applicable_no_symptoms: Non applicable (aucun symptôme)
+      group.Urinary_history: Antécédents urinaires
+      field.UR00.label.The_following_questions_concern: Les questions suivantes concernent vos reins et votre système urinaire.
+      field.UR01.label.Has_a_doctor_ever_diagnosed_you: Un médecin vous a-t-il déjà diagnostiqué une maladie des reins ou des voies urinaires ? (Plusieurs réponses possibles)
+      field.UR01.option.Chronic_kidney_disease: Insuffisance rénale chronique
+      field.UR01.option.Recurrent_kidney_stones: Calculs rénaux (lithiases) récidivants
+      field.UR01.option.Recurrent_urinary_tract: Infections urinaires récidivantes
+      field.UR01.option.Chronic_kidney_or_urinary: Maladie rénale ou urinaire chronique (autre)
+      field.UR01.option.None: Aucune
+      field.UR01.option.I_don_t_know: Je ne sais pas
+      field.UR02.label.Are_you_currently_being: Êtes-vous actuellement suivi(e) par un médecin pour un problème rénal ou urinaire ?
+      field.UR02.option.Yes: Oui
+      field.UR02.option.No: Non
+      field.UR02.option.I_don_t_know: Je ne sais pas
+      field.UR03.label.In_recent_months_have_you: Au cours des derniers mois, avez-vous présenté régulièrement l'un ou plusieurs des symptômes suivants qui ne sont PAS expliqués par un diagnostic urinaire ou rénal connu ? (Plusieurs réponses possibles)
+      field.UR03.option.Frequent_need_to_urinate: Besoin fréquent d'uriner
+      field.UR03.option.Night_time_urination_nocturia: Levers nocturnes pour uriner (nycturie)
+      field.UR03.option.Pain_or_burning_during_urination: Douleurs ou brûlures à la miction
+      field.UR03.option.Difficulty_completely_emptying: Difficulté à vider complètement la vessie
+      field.UR03.option.Unexplained_lower_back_pain: Douleurs lombaires basses non expliquées
+      field.UR03.option.None_of_these_symptoms: Aucun de ces symptômes
+      field.UR04.label.Do_these_urinary_issues_impact: Ces troubles urinaires ont-ils un impact sur votre sommeil, votre vie quotidienne ou votre travail ?
+      field.UR04.option.Not_at_all: Pas du tout
+      field.UR04.option.A_little: Un peu
+      field.UR04.option.A_lot: Beaucoup
+      field.UR04.option.Not_applicable_no_symptoms: Non applicable (aucun symptôme)
+      group.Personal_history_of_cancer: Antécédent personnel de cancer
+      field.CA00.label.The_following_questions_concern: Les questions suivantes concernent vos antécédents personnels de cancer.
+      field.CA01.label.Has_a_doctor_ever_diagnosed_you: Un médecin vous a-t-il déjà diagnostiqué un cancer, actuellement ou par le passé (même si vous êtes guéri(e)) ?
+      field.CA01.option.Yes: Oui
+      field.CA01.option.No: Non
+      field.CA01.option.I_don_t_know: Je ne sais pas
+      field.CA02.label.What_type_of_cancer_Multiple: Quel type de cancer ? (Plusieurs réponses possibles)
+      field.CA02.option.Breast: Sein
+      field.CA02.option.Prostate: Prostate
+      field.CA02.option.Lung: Poumon
+      field.CA02.option.Colorectal: Colorectal
+      field.CA02.option.Skin: Peau
+      field.CA02.option.Gynaecological: Gynécologique
+      field.CA02.option.Other_specify: Autre (précisez)
+      field.CA02_PRECISION.label.Specify_the_type_of_cancer: Précisez le type de cancer
+      group.Other_medical_history: Autres antécédents médicaux
+      field.OT00.label.The_following_questions_concern: Les questions suivantes concernent d'éventuels autres antécédents médicaux.
+      field.OT01.label.Apart_from_what_has_already: "En dehors de ce qui a déjà été abordé dans ce questionnaire, avez-vous un autre problème de santé chronique ou un antécédent médical important qui a un impact sur votre vie quotidienne ou votre travail ? (Par exemple : ophtalmologique, gynécologique, ORL, dermatologique, autre)"
+      field.OT01.option.Yes: Oui
+      field.OT01.option.No: Non
+      field.OT02.label.Can_you_specify_in_a_few_words: Pouvez-vous préciser en quelques mots ? (Champ texte libre – facultatif)
+      field.OT03.label.Do_these_issues_impact_your: Ces troubles ont-ils un impact sur votre vie quotidienne ou votre travail ?
+      field.OT03.option.Not_at_all: Pas du tout
+      field.OT03.option.A_little: Un peu
+      field.OT03.option.A_lot: Beaucoup
+      field.OT03.option.Not_applicable_no_symptoms: Non applicable (aucun symptôme)
+      field.OT04.label.Are_you_generally_up_to_date: Êtes-vous globalement à jour de vos vaccinations recommandées à l'âge adulte (selon votre médecin) ?
+      field.OT04.option.Yes: Oui
+      field.OT04.option.No: Non
+      field.OT04.option.I_don_t_know: Je ne sais pas
+      field.OT05.label.When_did_you_last_have_your: Quand avez-vous fait contrôler votre vue pour la dernière fois par un ophtalmologue ?
+      field.OT05.option.Less_than_1_year_ago: Il y a moins d'1 an
+      field.OT05.option.1_to_2_years_ago: Il y a 1 à 2 ans
+      field.OT05.option.More_than_2_years_ago: Il y a plus de 2 ans
+      field.OT05.option.I_have_never_had_a_check_up: Je n'ai jamais fait de contrôle
+      field.OT05.option.I_don_t_remember: Je ne sais plus
+      field.OT06.label.Have_you_ever_had_a_major: Avez-vous déjà subi une opération importante dans votre vie ?
+      field.OT06.option.Yes: Oui
+      field.OT06.option.No: Non
+      field.OT06.option.I_don_t_remember: Je ne sais plus
+      field.OT07.label.Which_one_if_you_remember: Laquelle (si vous vous en souvenez) ?
+      group.Family_history: Antécédents familiaux
+      field.FA00.label.The_following_questions_concern: Les questions suivantes concernent certaines maladies pouvant exister dans votre famille proche (parents, frères et sœurs).
+      field.FA01.label.Has_a_close_family_member_had: Un membre de votre famille proche a-t-il eu une maladie cardiovasculaire (infarctus, AVC, mort subite) à un âge précoce ?
+      field.FA01.option.Yes: Oui
+      field.FA01.option.No: Non
+      field.FA01.option.I_don_t_know: Je ne sais pas
+      field.FA02.label.Is_there_a_history_of_cancer_in: Existe-t-il dans votre famille proche des antécédents de cancer (sein, ovaire, prostate, colorectal, pancréas) ?
+      field.FA02.option.Yes: Oui
+      field.FA02.option.No: Non
+      field.FA02.option.I_don_t_know: Je ne sais pas
+      field.FA03.label.Do_close_family_members_have: Des membres de votre famille proche ont-ils un diabète de type 2 ?
+      field.FA03.option.Yes: Oui
+      field.FA03.option.No: Non
+      field.FA03.option.I_don_t_know: Je ne sais pas
+      section.Dental_Health: Santé dentaire
+      field.DHDC01.label.How_often_do_you_usually_brush: A quelle fréquence vous brossez-vous les dents habituellement?
+      field.DHDC01.option.More_than_twice_a_day: Plus de deux fois par jour
+      field.DHDC01.option.Twice_a_day: Deux fois par jour
+      field.DHDC01.option.Once_a_day: Une fois par jour
+      field.DHDC01.option.Less_than_once_a_day: Moins d’une fois par jour
+      field.DHDC01.option.Never: Jamais
+      field.DHDC01.option.Not_applicable_according_to: Non applicable (d'après le répondant)
+      field.DHDC02.label.Overall_how_would_you_rate_the: Globalement, comment qualifieriez-vous l’état de vos dents et de vos gencives ?
+      field.DHDC02.option.Very_good: Très bon
+      field.DHDC02.option.Good: Bon
+      field.DHDC02.option.Neither_good_nor_bad: Ni bon, ni mauvais
+      field.DHDC02.option.Bad: Mauvais
+      field.DHDC02.option.Very_bad: Très mauvais
+      field.DHDC03.label.In_the_past_12_months_have_you: Au cours des 12 derniers mois, avez-vous eu des douleurs dans votre bouche?
+      field.DHDC03.option.Yes: Oui
+      field.DHDC03.option.No: Non
+      field.DHDC04.label.When_did_you_last_visit_your: Quand avez-vous consulté  votre dentiste ou orthodontiste pour la dernière fois?
+      field.DHDC04.option.Less_than_6_months_ago: Il y a moins de 6 mois
+      field.DHDC04.option.6_months_or_more_ago_but_less: Il y a 6 moins ou plus, mais moins de 12 mois.
+      field.DHDC04.option.12_months_or_more_ago: Il y a 12 mois ou plus
+      field.DHDC04.option.Never: Jamais
+      field.DHDC04.option.Don_t_know: Ne sait pas
+      section.Cancer_Screening: Dépistage du cancer
+      group.Family_history_of_cancer: Antécédents familiaux de cancer
+      field.SC02.label.Is_there_a_history_of_cancer_in: Existe-t-il dans votre famille proche des antécédents de cancer (sein, ovaire, prostate, colorectal, pancréas) ?
+      field.SC02.option.Yes: Oui
+      field.SC02.option.No: Non
+      field.SC02.option.I_don_t_know: Je ne sais pas
+      group.Prostate_cancer.: Cancer de la prostate.
+      field.SC20.label.IPSS_International_Prostate: "IPSS : International Prostate Score Symptom"
+      field.SC21.label.In_the_past_month_how_often: Au cours du dernier mois, avec quelle fréquence avez-vous eu la sensation que votre vessie n’était pas complètement vidée après avoir uriné ?
+      field.SC21.option.Never: Jamais
+      field.SC21.option.About_1_time_in_5: Environ 1 fois sur 5
+      field.SC21.option.About_1_time_in_3: Environ 1 fois sur 3
+      field.SC21.option.About_1_time_in_2: Environ 1 fois sur 2
+      field.SC21.option.About_2_times_in_3: Environ 2 fois sur 3
+      field.SC21.option.Almost_always: Presque toujours
+      field.SC22.label.In_the_past_month_how_often: Au cours du dernier mois, avec quelle fréquence avez-vous eu besoin d'uriner moins de 2 heures après avoir fini d'uriner ?
+      field.SC22.option.Never: Jamais
+      field.SC22.option.About_1_time_in_5: Environ 1 fois sur 5
+      field.SC22.option.About_1_time_in_3: Environ 1 fois sur 3
+      field.SC22.option.About_1_time_in_2: Environ 1 fois sur 2
+      field.SC22.option.About_2_times_in_3: Environ 2 fois sur 3
+      field.SC22.option.Almost_always: Presque toujours
+      field.SC23.label.In_the_past_month_how_often: Au cours du dernier mois, avec quelle fréquence avez-vous eu une interruption du jet d'urine, c'est-à-dire démarrage de la miction puis arrêt puis redémarrage ?
+      field.SC23.option.Never: Jamais
+      field.SC23.option.About_1_time_in_5: Environ 1 fois sur 5
+      field.SC23.option.About_1_time_in_3: Environ 1 fois sur 3
+      field.SC23.option.About_1_time_in_2: Environ 1 fois sur 2
+      field.SC23.option.About_2_times_in_3: Environ 2 fois sur 3
+      field.SC23.option.Almost_always: Presque toujours
+      field.SC24.label.In_the_past_month_after_feeling: Au cours du dernier mois, après avoir ressenti le besoin d'uriner, avec quelle fréquence avez-vous eu des difficultés à vous retenir d'uriner ?
+      field.SC24.option.Never: Jamais
+      field.SC24.option.About_1_time_in_5: Environ 1 fois sur 5
+      field.SC24.option.About_1_time_in_3: Environ 1 fois sur 3
+      field.SC24.option.About_1_time_in_2: Environ 1 fois sur 2
+      field.SC24.option.About_2_times_in_3: Environ 2 fois sur 3
+      field.SC24.option.Almost_always: Presque toujours
+      field.SC25.label.In_the_past_month_how_often: Au cours du dernier mois, avec quelle fréquence avez-vous eu une diminution de la taille ou de la force du jet d'urine ?
+      field.SC25.option.Never: Jamais
+      field.SC25.option.About_1_time_in_5: Environ 1 fois sur 5
+      field.SC25.option.About_1_time_in_3: Environ 1 fois sur 3
+      field.SC25.option.About_1_time_in_2: Environ 1 fois sur 2
+      field.SC25.option.About_2_times_in_3: Environ 2 fois sur 3
+      field.SC25.option.Almost_always: Presque toujours
+      field.SC26.label.In_the_past_month_how_often: Au cours du dernier mois, avec quelle fréquence avez-vous dû forcer ou pousser pour commencer à uriner ?
+      field.SC26.option.Never: Jamais
+      field.SC26.option.About_1_time_in_5: Environ 1 fois sur 5
+      field.SC26.option.About_1_time_in_3: Environ 1 fois sur 3
+      field.SC26.option.About_1_time_in_2: Environ 1 fois sur 2
+      field.SC26.option.About_2_times_in_3: Environ 2 fois sur 3
+      field.SC26.option.Almost_always: Presque toujours
+      field.SC27.label.In_the_past_month_how_many: Au cours du dernier mois écoulé, combien de fois par nuit, en moyenne, vous êtes-vous levé pour uriner (entre le moment de votre coucher le soir et celui de votre lever définitif le matin) ?
+      field.SC27.option.Never: Jamais
+      field.SC27.option.1_time: 1 fois
+      field.SC27.option.2_times: 2 fois
+      field.SC27.option.3_times: 3 fois
+      field.SC27.option.4_times: 4 fois
+      field.SC27.option.5_times: 5 fois
+      field.SC28.label.Total_score: "Score total:"
+      field.SC29.label.IPSS_notes_0_7_mild_8_19: "IPSS notes: 0 – 7 = léger; 8 – 19 = modéré; 20 – 35 = sévère"
+      group.Colorectal_cancer_screening: "Dépistage du cancer colorectal:"
+      field.SC31.label.There_is_a_screening_test_for: Il existe un test de dépistage du cancer de l’intestin (colorectal) qui consiste à détecter la présence de sang dans les selles. Avez-vous déjà eu ce genre de test?
+      field.SC31.option.Yes: Oui
+      field.SC31.option.No: Non
+      field.SC32.label.When_did_you_last_have_a_test: Quand avez-vous eu un test pour détecter la présence de sang dans les selles pour la dernière fois?
+      field.SC32.option.Less_than_2_years_ago: Il y a moins de 2 ans
+      field.SC32.option.2_years_or_more_ago: Il y a 2 ans ou plus
+      field.SC32.option.Never: Jamais
+      field.SC32.option.I_don_t_know: Je ne sais pas
+      field.SC33.label.A_more_thorough_examination: Un examen plus sophistiqué consiste en un examen interne (endoscopie) de l'intestin en utilisant une sonde. Cela s'appelle une "colonoscopie". Avez-vous déjà eu une colonoscopie?
+      field.SC33.option.Yes: Oui
+      field.SC33.option.No: Non
+      field.SC34.label.When_did_you_last_have_a: Quand avez-vous eu une colonoscopie pour la dernière fois?
+      field.SC34.option.Less_than_5_years_ago: Il y a moins de 5 ans
+      field.SC34.option.More_than_5_years_ago_but_less: Il y a plus de 5 ans mais moins de 10 ans
+      field.SC34.option.More_than_10_years_ago: Il y a plus de 10 ans
+      group.Breast_cancer_screening: "Dépistage du cancer du sein:"
+      field.SC36.label.Have_you_ever_had_a_mammography: Avez-vous déjà passé une mammographie (radiographie d’un ou de vos deux seins)?
+      field.SC36.option.Yes: Oui
+      field.SC36.option.No: Non
+      field.SC36.option.I_don_t_know: Je ne sais pas
+      field.SC37.label.When_did_you_last_have_a: Quand avez-vous passé une mammographie pour la dernière fois?
+      field.SC37.option.Less_than_2_years_ago: Il y a moins de 2 ans
+      field.SC37.option.2_years_or_more_ago: Il y a 2 ans ou plus
+      field.SC37.option.I_don_t_know: Je ne sais pas
+      group.Cervical_cancer_screening: "Dépistage du cancer de l'utérus:"
+      field.SC39.label.Have_you_ever_had_a_cervical: Avez-vous déjà eu un frottis du col de l’utérus?
+      field.SC39.option.Yes: Oui
+      field.SC39.option.No: Non
+      field.SC40.label.When_did_you_last_have_a: Quand avez-vous eu un frottis du col de l’utérus pour la dernière fois?
+      field.SC40.option.Less_than_3_years_ago: Il y a moins de 3 ans
+      field.SC40.option.3_years_or_more_ago: Il y a 3 ans ou plus
+      field.SC40.option.I_don_t_know: Je ne sais pas
+      group.Skin_cancer: Cancer de la peau
+      field.SC42.label.Do_you_have_more_than_50_moles: Avez-vous plus de 50 grains de beauté sur le corps ?
+      field.SC42.option.Yes: Oui
+      field.SC42.option.No: Non
+      field.SC42.option.I_don_t_know: Je ne sais pas
+      field.SC44.label.How_does_your_skin_generally: Comment votre peau réagit-elle généralement au soleil ?
+      field.SC44.option.I_burn_easily_I_tan_little_or: Je brûle facilement, je bronze peu ou pas
+      field.SC44.option.I_sometimes_burn_then_tan: Je brûle parfois puis je bronze
+      field.SC44.option.I_tan_easily_and_rarely_burn: Je bronze facilement et je brûle rarement
+      field.SC44.option.I_don_t_know: Je ne sais pas
+      field.SC45.label.Have_you_been_repeatedly: Avez-vous été fortement exposé(e) au soleil de manière répétée au cours de votre vie ? (travail en extérieur, loisirs fréquents au soleil, séjours prolongés dans des régions très ensoleillées, etc.)
+      field.SC45.option.Yes: Oui
+      field.SC45.option.No: Non
+      field.SC45.option.I_don_t_know: Je ne sais pas
+      field.SC46.label.Have_you_ever_used_tanning_beds: Avez-vous déjà utilisé des cabines de bronzage (UV artificiels) ?
+      field.SC46.option.Never: Jamais
+      field.SC46.option.Occasionally: Occasionnellement
+      field.SC46.option.Regularly_in_the_past_or: Régulièrement (par le passé ou actuellement)
+      field.SC47.label.Have_you_ever_had_your_moles_or: Avez-vous déjà fait examiner vos grains de beauté ou votre peau par un médecin ou un dermatologue ?
+      field.SC47.option.Yes: Oui
+      field.SC47.option.No: Non
+      field.SC47.option.I_don_t_know: Je ne sais pas
+      group.Lung_cancer: Cancer du poumon
+      field.SC48.label.Have_you_smoked_the_equivalent: "Avez-vous fumé au moins l’équivalent d’un paquet par jour pendant 20 ans (ou plus) ? (ou l’équivalent : ex. 2 paquets/j pendant 10 ans)"
+      field.SC48.option.Yes: Oui
+      field.SC48.option.No: Non
+      field.SC48.option.I_don_t_know: Je ne sais pas
+      section.Cardiovascular_Diseases: Maladies cardio-vasculaires
+      field.PR01.label.Has_your_blood_pressure_ever: Votre tension artérielle a-t-elle déjà été mesurée par un médecin, une infirmière ou un autre professionnel de la santé?
+      field.PR01.option.Yes: Oui
+      field.PR01.option.No: Non
+      field.PR01.option.I_don_t_know: Je ne sais pas
+      field.PR03.label.If_your_blood_pressure_was: Si votre tension artérielle a été mesurée il y a moins d'un an, vous souvenez vous de combien elle était ?
+      field.PR03.option.Above_140_90_mmHg: Supérieure à 140/90 mmHg
+      field.PR03.option.Between_120_70_and_140_90_mmHg: Entre 120/70 et 140/90 mmHg
+      field.PR03.option.Below_120_70_mmHg: Inférieure à 120/70 mmHg
+      field.PR03.option.I_don_t_remember: Je ne sais plus
+      field.PR04.label.When_did_you_last_have_a_blood: Quand avez-vous réalisé une analyse de sang pour la dernière fois ?
+      field.PR04.option.Less_than_a_year_ago: Moins d'un an
+      field.PR04.option.More_than_1_year_ago: Il y a plus d'1 an
+      field.PR04.option.I_don_t_remember: Je ne sais plus
+      section.Physical_Pain: Douleur physique
+      field.PI02.label.Do_you_currently_experience: Ressentez-vous actuellement des douleurs persistantes (depuis 3 mois ou plus) qui ont un impact sur votre vie quotidienne ou votre travail ?
+      field.PI02.option.Yes: Oui
+      field.PI02.option.No: Non
+      section.Mental_Health: Santé mentale
+      group.Perceived_stress: Stress perçu
+      field.SM02.label.In_the_past_month_how_often: Au cours du dernier mois, à quelle fréquence avez-vous été bouleversé à cause d'un événement inattendu?
+      field.SM02.option.Never: Jamais
+      field.SM02.option.Almost_never: Presque jamais
+      field.SM02.option.Sometimes: Parfois
+      field.SM02.option.Often: Souvent
+      field.SM02.option.Very_often: Très souvent
+      field.SM03.label.In_the_past_month_how_often: Au cours du dernier mois, combien de fois avez-vous eu l'impression de ne pas pouvoir contrôler les choses importantes de votre vie?
+      field.SM03.option.Never: Jamais
+      field.SM03.option.Almost_never: Presque jamais
+      field.SM03.option.Sometimes: Parfois
+      field.SM03.option.Often: Souvent
+      field.SM03.option.Very_often: Très souvent
+      field.SM04.label.In_the_past_month_how_often: Au cours du dernier mois, à quelle fréquence vous êtes-vous senti nerveux et stressé?
+      field.SM04.option.Never: Jamais
+      field.SM04.option.Almost_never: Presque jamais
+      field.SM04.option.Sometimes: Parfois
+      field.SM04.option.Often: Souvent
+      field.SM04.option.Very_often: Très souvent
+      field.SM05.label.In_the_past_month_how_often: Au cours du dernier mois, à quelle fréquence vous êtes-vous senti confiant quant à votre capacité à gérer vos problèmes personnels?
+      field.SM05.option.Never: Jamais
+      field.SM05.option.Almost_never: Presque jamais
+      field.SM05.option.Sometimes: Parfois
+      field.SM05.option.Often: Souvent
+      field.SM05.option.Very_often: Très souvent
+      field.SM06.label.In_the_past_month_how_often: Au cours du dernier mois, à quelle fréquence avez-vous senti que les choses allaient dans votre sens?
+      field.SM06.option.Never: Jamais
+      field.SM06.option.Almost_never: Presque jamais
+      field.SM06.option.Sometimes: Parfois
+      field.SM06.option.Often: Souvent
+      field.SM06.option.Very_often: Très souvent
+      field.SM07.label.In_the_past_month_how_often: Au cours du dernier mois, combien de fois avez-vous constaté que vous ne pouviez pas faire face à toutes les choses que vous deviez faire?
+      field.SM07.option.Never: Jamais
+      field.SM07.option.Almost_never: Presque jamais
+      field.SM07.option.Sometimes: Parfois
+      field.SM07.option.Often: Souvent
+      field.SM07.option.Very_often: Très souvent
+      field.SM08.label.In_the_past_month_how_often: Au cours du dernier mois, à quelle fréquence avez-vous pu contrôler les irritations dans votre vie?
+      field.SM08.option.Never: Jamais
+      field.SM08.option.Almost_never: Presque jamais
+      field.SM08.option.Sometimes: Parfois
+      field.SM08.option.Often: Souvent
+      field.SM08.option.Very_often: Très souvent
+      field.SM09.label.In_the_past_month_how_often: Au cours du dernier mois, à quelle fréquence avez-vous senti que vous étiez au courant des choses?
+      field.SM09.option.Never: Jamais
+      field.SM09.option.Almost_never: Presque jamais
+      field.SM09.option.Sometimes: Parfois
+      field.SM09.option.Often: Souvent
+      field.SM09.option.Very_often: Très souvent
+      field.SM10.label.In_the_past_month_how_often: Au cours du dernier mois, à quelle fréquence avez-vous été irrité à cause de choses qui se sont déroulées hors de votre contrôle?
+      field.SM10.option.Never: Jamais
+      field.SM10.option.Almost_never: Presque jamais
+      field.SM10.option.Sometimes: Parfois
+      field.SM10.option.Often: Souvent
+      field.SM10.option.Very_often: Très souvent
+      field.SM11.label.In_the_past_month_how_often: Au cours du dernier mois, à quelle fréquence avez-vous senti que les difficultés s'accumulaient si haut que vous ne pouviez pas les surmonter?
+      field.SM11.option.Never: Jamais
+      field.SM11.option.Almost_never: Presque jamais
+      field.SM11.option.Sometimes: Parfois
+      field.SM11.option.Often: Souvent
+      field.SM11.option.Very_often: Très souvent
+      field.SM12.label.Total_score: "Score total:"
+      group.Overall_well_being_energy_and: Bien-être global, énergie et fatigue
+      field.SM14.label.On_a_scale_of_0_to_10_where_0: Sur une échelle de 0 à 10, où 0 signifie “pas du tout satisfait(e)” et 10 signifie “totalement satisfait(e)”, quel degré de satisfaction éprouvez-vous actuellement à l’égard de votre vie ?
+      field.SM15.label.In_recent_weeks_to_what_extent: Au cours des dernières semaines, dans quelle mesure vous êtes-vous senti(e) énergique ou dynamique ?
+      field.SM16.label.In_recent_weeks_to_what_extent: Au cours des dernières semaines, dans quelle mesure vous êtes-vous senti(e) fatigué(e) ou épuisé(e) ?
+      group.GAD_7_Scale_anxiety_disorder: Echelle Gad7, dépistage du trouble anxieux
+      field.SM35.label.Over_the_last_2_weeks_how_often: Au cours des 2 dernières semaines. Selon quelle fréquence avez-vous été gêné(e) par les problèmes suivants ?
+      field.SM36.label.Feeling_nervous_anxious_or_on: Un sentiment de nervosité, d’anxiété ou de tension
+      field.SM36.option.Never: Jamais
+      field.SM36.option.Several_days: Plusieurs jours
+      field.SM36.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM36.option.Nearly_every_day: Presque tous les jours
+      field.SM37.label.Not_being_able_to_stop_or: Une incapacité à arrêter de s’inquiéter ou à contrôler ses inquiétudes
+      field.SM37.option.Never: Jamais
+      field.SM37.option.Several_days: Plusieurs jours
+      field.SM37.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM37.option.Nearly_every_day: Presque tous les jours
+      field.SM38.label.Worrying_too_much_about: Une inquiétude excessive à propos de différentes choses
+      field.SM38.option.Never: Jamais
+      field.SM38.option.Several_days: Plusieurs jours
+      field.SM38.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM38.option.Nearly_every_day: Presque tous les jours
+      field.SM39.label.Trouble_relaxing: Des difficultés à se détendre
+      field.SM39.option.Never: Jamais
+      field.SM39.option.Several_days: Plusieurs jours
+      field.SM39.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM39.option.Nearly_every_day: Presque tous les jours
+      field.SM40.label.Being_so_restless_that_it_is: Une agitation telle qu’il est difficile à tenir en place
+      field.SM40.option.Never: Jamais
+      field.SM40.option.Several_days: Plusieurs jours
+      field.SM40.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM40.option.Nearly_every_day: Presque tous les jours
+      field.SM41.label.Becoming_easily_annoyed_or: Une tendance à être facilement contrarié(e) ou irritable
+      field.SM41.option.Never: Jamais
+      field.SM41.option.Several_days: Plusieurs jours
+      field.SM41.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM41.option.Nearly_every_day: Presque tous les jours
+      field.SM42.label.Feeling_afraid_as_if_something: Un sentiment de peur comme si quelque chose de terrible risquait de se produire
+      field.SM42.option.Never: Jamais
+      field.SM42.option.Several_days: Plusieurs jours
+      field.SM42.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM42.option.Nearly_every_day: Presque tous les jours
+      field.SM43.label.Total_score: "Score total:"
+      group.PHQ_9_Scale_depression_screening: Echelle QSP9, Dépistage de la dépression
+      field.SM45.label.Please_answer_each_question_by: Veuillez répondre à chacune des questions en encerclant l’énoncé qui correspond le mieux à votre situation
+      field.SM46.label.Over_the_last_two_weeks_how: Au cours des deux dernières semaines, à quelle fréquence avez-vous été dérangé par les problèmes suivants?
+      field.SM47.label.Little_interest_or_pleasure_in: Peu d’intérêt ou de plaisir à faire les choses
+      field.SM47.option.Never: Jamais
+      field.SM47.option.Several_days: Plusieurs jours
+      field.SM47.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM47.option.Nearly_every_day: Presque tous les jours
+      field.SM48.label.Feeling_down_depressed_or: Vous sentir triste, déprimé ou désespéré
+      field.SM48.option.Never: Jamais
+      field.SM48.option.Several_days: Plusieurs jours
+      field.SM48.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM48.option.Nearly_every_day: Presque tous les jours
+      field.SM49.label.Trouble_falling_asleep_staying: Difficultés à vous endormir, à rester endormi ou trop dormir
+      field.SM49.option.Never: Jamais
+      field.SM49.option.Several_days: Plusieurs jours
+      field.SM49.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM49.option.Nearly_every_day: Presque tous les jours
+      field.SM50.label.Feeling_tired_or_having_little: Vous sentir fatigué ou avoir peu d’énergie
+      field.SM50.option.Never: Jamais
+      field.SM50.option.Several_days: Plusieurs jours
+      field.SM50.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM50.option.Nearly_every_day: Presque tous les jours
+      field.SM51.label.Poor_appetite_or_overeating: Peu d’appétit ou trop d’appétit
+      field.SM51.option.Never: Jamais
+      field.SM51.option.Several_days: Plusieurs jours
+      field.SM51.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM51.option.Nearly_every_day: Presque tous les jours
+      field.SM52.label.Feeling_bad_about_yourself_or: Mauvaise perception de vous-même, vous pensez que vous êtes un perdant ou que vous n’avez pas satisfait vos propres attentes ou celles de votre famille
+      field.SM52.option.Never: Jamais
+      field.SM52.option.Several_days: Plusieurs jours
+      field.SM52.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM52.option.Nearly_every_day: Presque tous les jours
+      field.SM53.label.Trouble_concentrating_on_things: Difficultés à vous concentrer sur des choses telles que lire le journal ou regarder la télévision
+      field.SM53.option.Never: Jamais
+      field.SM53.option.Several_days: Plusieurs jours
+      field.SM53.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM53.option.Nearly_every_day: Presque tous les jours
+      field.SM54.label.Moving_or_speaking_so_slowly: Vous bougez ou vous parlez si lentement que les autres personnes ont pu le remarquer. Ou, au contraire, vous êtes si agité que vous bougez beaucoup plus que d’habitude.
+      field.SM54.option.Never: Jamais
+      field.SM54.option.Several_days: Plusieurs jours
+      field.SM54.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM54.option.Nearly_every_day: Presque tous les jours
+      field.SM55.label.Thoughts_that_you_would_be: Vous avez pensé que vous seriez mieux mort ou pensé à vous blesser d’une façon ou d’une autre.
+      field.SM55.option.Never: Jamais
+      field.SM55.option.Several_days: Plusieurs jours
+      field.SM55.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM55.option.Nearly_every_day: Presque tous les jours
+      field.SM56.label.Total_score: "Score total:"
+      field.SM57.label.If_the_patient_answers_yes_to: Si le patient répond oui à la question 9, une évaluation du risque suicidaire ou de l’auto-agressivité par un professionnel de la santé ou des services sociaux qualifié est conseillée.
+      field.SM58.label.If_you_checked_off_any_problems: "Si vous avez coché au moins un des problèmes nommés dans ce questionnaire, répondez à la question suivante : Dans quelle mesure ce ou ces problèmes ont-ils rendu difficiles votre travail, vos tâches à la maison ou votre capacité à bien vous entendre avec les autres?"
+      field.SM58.option.Not_difficult_at_all: Pas du tout difficile
+      field.SM58.option.Somewhat_difficult: Plutôt difficile
+      field.SM58.option.Very_difficult: Très difficile
+      field.SM58.option.Extremely_difficult: Extrêmement difficile
+      group.Depression_and_anxiety_disorders: Dépression et troubles anxieux
+      field.SM60.label.Over_the_last_2_weeks_how_often: "Au cours des 2 dernières semaines, à quelle fréquence avez-vous rencontré des difficultés telles que :"
+      field.SM61.label.Feeling_nervous_anxious_or_on: Vous sentir nerveux(se), anxieux(se) ou tendu(e)
+      field.SM61.option.Not_at_all: Pas du tout
+      field.SM61.option.Several_days: Plusieurs jours
+      field.SM61.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM61.option.Nearly_every_day: Presque tous les jours
+      field.SM62.label.Not_being_able_to_stop_or: Ne pas pouvoir arrêter de vous inquiéter ou ne pas pouvoir contrôler vos inquiétudes
+      field.SM62.option.Not_at_all: Pas du tout
+      field.SM62.option.Several_days: Plusieurs jours
+      field.SM62.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM62.option.Nearly_every_day: Presque tous les jours
+      field.SM63.label.Worrying_too_much_about: Trop vous soucier à propos de différentes choses
+      field.SM63.option.Not_at_all: Pas du tout
+      field.SM63.option.Several_days: Plusieurs jours
+      field.SM63.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM63.option.Nearly_every_day: Presque tous les jours
+      field.SM64.label.Having_trouble_relaxing: Avoir des difficultés à vous détendre
+      field.SM64.option.Not_at_all: Pas du tout
+      field.SM64.option.Several_days: Plusieurs jours
+      field.SM64.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM64.option.Nearly_every_day: Presque tous les jours
+      field.SM65.label.Being_so_restless_that_it_is: Être si agité(e) qu’il vous est difficile de tenir en place
+      field.SM65.option.Not_at_all: Pas du tout
+      field.SM65.option.Several_days: Plusieurs jours
+      field.SM65.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM65.option.Nearly_every_day: Presque tous les jours
+      field.SM66.label.Being_easily_annoyed_or: Être facilement contrarié(e) ou irritable
+      field.SM66.option.Not_at_all: Pas du tout
+      field.SM66.option.Several_days: Plusieurs jours
+      field.SM66.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM66.option.Nearly_every_day: Presque tous les jours
+      field.SM67.label.Feeling_afraid_as_if_something: Vous sentir effrayé(e), comme si quelque chose de terrible allait se produire
+      field.SM67.option.Not_at_all: Pas du tout
+      field.SM67.option.Several_days: Plusieurs jours
+      field.SM67.option.More_than_half_the_days: Plus de la moitié du temps
+      field.SM67.option.Nearly_every_day: Presque tous les jours
+      section.Physical_Activity: Activité physique
+      field.PA01.label.The_following_questions_concern: Les questions suivantes concernent vos activités physiques au cours d’une semaine normale, que ce soit dans le cadre du travail, des déplacements ou des loisirs.
+      group.Work_and_Daily_Activities: Travail et Activités Quotidiennes
+      field.PA05.label.Generally_speaking_would_you: "De manière générale, diriez-vous que vous êtes physiquement :"
+      field.PA05.option.Very_inactive: Très peu actif(ve)
+      field.PA05.option.Moderately_active: Modérément actif(ve)
+      field.PA05.option.Active: Actif(ve)
+      field.PA05.option.Very_active: Très actif(ve)
+      group.Commuting_and_Transport: Déplacements et Transports
+      field.PA08.label.In_a_typical_week_how_many_days: Au cours d’une semaine normale, combien de jours pratiquez-vous au moins 30 minutes d’activité physique modérée ou intense ? (marche rapide, vélo, sport, fitness, natation, jogging, etc.)
+      field.PA08.option.0_days: 0 jour
+      field.PA08.option.1_to_2_days: 1 à 2 jours
+      field.PA08.option.3_to_4_days: 3 à 4 jours
+      field.PA08.option.5_days_or_more: 5 jours ou plus
+      field.PA09.label.Do_you_regularly_engage_in_a: Pratiquez-vous régulièrement une activité sportive ou de loisir ?
+      field.PA09.option.No: Non
+      field.PA09.option.Yes_occasionally: Oui, Occasionnellement
+      field.PA09.option.Yes_1_to_2_times_per_week: Oui, 1 à 2 fois par semaine
+      field.PA09.option.Yes_3_times_per_week_or_more: Oui, 3 fois par semaine ou plus
+      field.PA10.label.In_a_typical_week_how_many_days: Au cours d’une semaine normale, combien de jours pratiquez-vous des exercices de renforcement musculaire ? (musculation, gainage, exercices contre résistance, etc.)
+      field.PA10.option.0_days: 0 jour
+      field.PA10.option.1_day: 1 jour
+      field.PA10.option.2_days: 2 jours
+      field.PA10.option.3_days_or_more: 3 jours ou plus
+      field.PA11.label.On_a_typical_day_how_much_time: Au cours d’une journée habituelle, combien de temps passez-vous assis(e) ou couché(e) (hors sommeil) ? (au travail, à la maison, dans les transports, devant un écran, etc.)
+      field.PA11.option.Less_than_6_hours_per_day: Moins de 6 heures par jour
+      field.PA11.option.6_to_8_hours_per_day: 6 à 8 heures par jour
+      field.PA11.option.8_to_10_hours_per_day: 8 à 10 heures par jour
+      field.PA11.option.More_than_10_hours_per_day: Plus de 10 heures par jour
+      field.PA12.label.Is_your_work_physically: Votre activité professionnelle est-elle physiquement exigeante ?
+      field.PA12.option.No_mainly_seated_or_standing: Non, principalement assise ou debout
+      field.PA12.option.Yes_moderately_active_walking: Oui, modérément active (marche, déplacements fréquents)
+      field.PA12.option.Yes_physically_demanding: Oui, physiquement exigeante
+      section.Nutritional_Habits: Habitudes nutritionnelles
+      field.NH01.label.How_often_do_you_eat_fruit: A quelle fréquence mangez-vous des fruits? Les jus pressés de fruits frais, à base de concentré ou de fruits transformés et les jus édulcorés ne sont pas inclus
+      field.NH01.option.Every_day: Tous les jours
+      field.NH01.option.4_to_6_times_per_week: 4 à 6 fois par semaine
+      field.NH01.option.1_to_3_times_per_week: 1 à 3 fois par semaine
+      field.NH01.option.Less_than_once_a_week: Moins d'une fois par semaine
+      field.NH01.option.Never: Jamais
+      field.NH02.label.How_often_do_you_eat_vegetables: A quelle fréquence mangez-vous des légumes ou de la salade ? (Hors pommes de terre, soupes et jus)
+      field.NH02.option.Every_day: Tous les jours
+      field.NH02.option.4_to_6_times_per_week: 4 à 6 fois par semaine
+      field.NH02.option.1_to_3_times_per_week: 1 à 3 fois par semaine
+      field.NH02.option.Less_than_once_a_week: Moins d'une fois par semaine
+      field.NH02.option.Never: Jamais
+      field.NH03.label.How_often_do_you_drink_sugary: À quelle fréquence consommez-vous des boissons sucrées (sodas, limonades, thé glacé, jus sucrés) ?(Hors versions light / zéro)
+      field.NH03.option.Every_day: Tous les jours
+      field.NH03.option.4_to_6_times_per_week: 4 à 6 fois par semaine
+      field.NH03.option.1_to_3_times_per_week: 1 à 3 fois par semaine
+      field.NH03.option.Less_than_once_a_week: Moins d'une fois par semaine
+      field.NH03.option.Never: Jamais
+      field.NH04.label.How_often_do_you_eat_sweet_or: À quelle fréquence consommez-vous des collations sucrées ou salées (bonbons, chocolat, pâtisseries, biscuits, chips…) ?
+      field.NH04.option.Every_day: Tous les jours
+      field.NH04.option.4_to_6_times_per_week: 4 à 6 fois par semaine
+      field.NH04.option.1_to_3_times_per_week: 1 à 3 fois par semaine
+      field.NH04.option.Less_than_once_a_week: Moins d'une fois par semaine
+      field.NH04.option.Never: Jamais
+      field.NH05.label.On_average_how_much_water_do: En moyenne, combien d’eau buvez-vous par jour (hors café, thé, sodas, alcool) ?
+      field.NH05.option.Less_than_1_litre: Moins de 1 litre
+      field.NH05.option.About_1_to_1.5_litres: Environ 1 à 1,5 litre
+      field.NH05.option.More_than_1.5_litres: Plus de 1,5 litre
+      field.NH05.option.I_don_t_know: Je ne sais pas
+      field.NH06.label.How_often_do_you_eat_breakfast: A quelle fréquence prenez-vous un petit déjeuner (le matin)?
+      field.NH06.option.Every_day: Tous les jours
+      field.NH06.option.5_to_6_times_per_week: 5 à 6 fois par semaine
+      field.NH06.option.2_to_4_times_per_week: 2 à 4 fois par semaine
+      field.NH06.option.Rarely: Rarement
+      field.NH06.option.Never: Jamais
+      field.NH07.label.Do_you_snack_between_meals: Vous arrive-t-il de grignoter en dehors des repas ?
+      field.NH07.option.Yes_often: Oui, souvent
+      field.NH07.option.Yes_sometimes: Oui, parfois
+      field.NH07.option.No_rarely: Non, rarement
+      field.NH07.option.No_never: Non, jamais
+      field.NH08.label.How_often_do_you_eat_processed: À quelle fréquence consommez-vous des produits alimentaires transformés ou ultra-transformés (plats préparés, charcuterie, pizzas surgelées, etc.) ?
+      field.NH08.option.Very_often: Très souvent
+      field.NH08.option.Often: Souvent
+      field.NH08.option.Occasionally: Occasionnellement
+      field.NH08.option.Rarely: Rarement
+      field.NH08.option.Never: Jamais
+      field.NH09.label.How_often_do_you_eat_fast_food: À quelle fréquence consommez-vous des repas de type fast-food ?
+      field.NH09.option.Several_times_per_week: Plusieurs fois par semaine
+      field.NH09.option.About_once_a_week: Environ 1 fois par semaine
+      field.NH09.option.1_to_3_times_per_month: 1 à 3 fois par mois
+      field.NH09.option.Rarely: Rarement
+      field.NH09.option.Never: Jamais"
+      field.NH16.label.Do_you_have_any_food: Avez-vous des intolérances ou des allergies alimentaires?
+      field.NH17.label.Which_foods_are_you_intolerant: Quels sont les aliments que vous ne tolérez pas ou dont vous êtes allergique? (Plusieurs réponses possibles)
+      field.NH17.option.Milk_lactose: Lait (lactose)
+      field.NH17.option.Peanuts: Arachides
+      field.NH17.option.Walnuts: Noix
+      field.NH17.option.Hazelnuts: Noisettes
+      field.NH17.option.Other_nuts: Autres noix
+      field.NH17.option.Shellfish: Crustacés
+      field.NH17.option.Soy: Soja
+      field.NH17.option.Gluten_containing_cereals: Céréales contenant du gluten
+      field.NH17.option.Eggs: Œufs
+      field.NH17.option.Fish: Poisson
+      field.NH17.option.Other_specify: "Autre, spécifiez:"
+      field.NH18.label.Other_allergy_specify: "Autre allergique, spécifiez:"
+      field.NH19.label.Has_this_milk_lactose: Cette intolérance ou allergie au lait (lactose) a-t-elle été confirmée par un médecin?
+      field.NH19.option.Yes: Oui
+      field.NH19.option.No: Non
+      field.NH19.option.Don_t_know: Ne sait pas
+      field.NH20.label.Has_this_peanut_intolerance_or: Cette intolérance ou allergie aux arachides a-t-elle été confirmée par un médecin?
+      field.NH20.option.Yes: Oui
+      field.NH20.option.No: Non
+      field.NH20.option.Don_t_know: Ne sait pas
+      field.NH21.label.Has_this_nut_intolerance_or: Cette intolérance ou allergie aux noix a-t-elle été confirmée par un médecin?
+      field.NH21.option.Yes: Oui
+      field.NH21.option.No: Non
+      field.NH21.option.Don_t_know: Ne sait pas
+      field.NH22.label.Has_this_shellfish_intolerance: Cette intolérance ou allergie aux crustacés a-t-elle été confirmée par un médecin?
+      field.NH22.option.Yes: Oui
+      field.NH22.option.No: Non
+      field.NH22.option.Don_t_know: Ne sait pas
+      field.NH23.label.Has_this_soy_intolerance_or: Cette intolérance ou allergie au soja a-t-elle été confirmée par un médecin?
+      field.NH23.option.Yes: Oui
+      field.NH23.option.No: Non
+      field.NH23.option.Don_t_know: Ne sait pas
+      field.NH24.label.Has_this_gluten_intolerance_or: Cette intolérance ou allergie au gluten a-t-elle été confirmée par un médecin?
+      field.NH24.option.Yes: Oui
+      field.NH24.option.No: Non
+      field.NH24.option.Don_t_know: Ne sait pas
+      field.NH25.label.Has_this_egg_intolerance_or: Cette intolérance ou allergie aux œufs a-t-elle été confirmée par un médecin?
+      field.NH25.option.Yes: Oui
+      field.NH25.option.No: Non
+      field.NH25.option.Don_t_know: Ne sait pas
+      field.NH26.label.Has_this_fish_intolerance_or: Cette intolérance ou allergie au poisson a-t-elle été confirmée par un médecin?
+      field.NH26.option.Yes: Oui
+      field.NH26.option.No: Non
+      field.NH26.option.Don_t_know: Ne sait pas
+      field.NH27.label.Has_another_intolerance_or: Une autre intolérance ou allergie a-t-elle été confirmée par un médecin?
+      section.Sleep_Quality: Qualité du sommeil
+      field.CD01.label.This_questionnaire_assesses_the: Ce questionnaire permet d'évaluer la qualité de votre sommeil
+      field.CD02.label.Do_you_have_trouble_falling: Avez-vous du mal à vous endormir ?
+      field.CD02.option.Never: Jamais
+      field.CD02.option.Rarely: Rarement
+      field.CD02.option.Occasionally: Occasionnellement
+      field.CD02.option.Most_of_the_time: La plupart du temps
+      field.CD02.option.Always: Toujours
+      field.CD03.label.Do_you_have_trouble_staying: Avez-vous du mal à rester endormi ?
+      field.CD03.option.Never: Jamais
+      field.CD03.option.Rarely: Rarement
+      field.CD03.option.Occasionally: Occasionnellement
+      field.CD03.option.Most_of_the_time: La plupart du temps
+      field.CD03.option.Always: Toujours
+      field.CD04.label.Do_you_take_medication_to_help: Prenez vous des médicament pour vous aider à dormir ?
+      field.CD04.option.Never: Jamais
+      field.CD04.option.Rarely: Rarement
+      field.CD04.option.Occasionally: Occasionnellement
+      field.CD04.option.Most_of_the_time: La plupart du temps
+      field.CD04.option.Always: Toujours
+      field.CD05.label.Do_you_drink_alcohol_to_help: Prenez vous de l'alcool pour vous aider à dormir ?
+      field.CD05.option.Never: Jamais
+      field.CD05.option.Rarely: Rarement
+      field.CD05.option.Occasionally: Occasionnellement
+      field.CD05.option.Most_of_the_time: La plupart du temps
+      field.CD05.option.Always: Toujours
+      field.CD06.label.Is_there_a_health_problem_that: Y a-t-il un problème de santé qui perturbe votre sommeil ?
+      field.CD06.option.Never: Jamais
+      field.CD06.option.Rarely: Rarement
+      field.CD06.option.Occasionally: Occasionnellement
+      field.CD06.option.Most_of_the_time: La plupart du temps
+      field.CD06.option.Always: Toujours
+      field.CD07.label.Have_you_lost_all_interest_in: Avez-vous perdu tout intérêt pour vos activités et vos hobbies ?
+      field.CD07.option.Never: Jamais
+      field.CD07.option.Rarely: Rarement
+      field.CD07.option.Occasionally: Occasionnellement
+      field.CD07.option.Most_of_the_time: La plupart du temps
+      field.CD07.option.Always: Toujours
+      field.CD08.label.Do_you_feel_sad_irritable_or: Vous sentez vous triste, irritable ou désespéré ?
+      field.CD08.option.Never: Jamais
+      field.CD08.option.Rarely: Rarement
+      field.CD08.option.Occasionally: Occasionnellement
+      field.CD08.option.Most_of_the_time: La plupart du temps
+      field.CD08.option.Always: Toujours
+      field.CD09.label.Do_you_feel_nervous_or_anxious: Vous sentez vous nerveux ou inquiet ?
+      field.CD09.option.Never: Jamais
+      field.CD09.option.Rarely: Rarement
+      field.CD09.option.Occasionally: Occasionnellement
+      field.CD09.option.Most_of_the_time: La plupart du temps
+      field.CD09.option.Always: Toujours
+      field.CD10.label.Do_you_think_there_is_something: Pensez vous qu'il y a quelque chose qui ne va pas avec votre corps ?
+      field.CD10.option.Never: Jamais
+      field.CD10.option.Rarely: Rarement
+      field.CD10.option.Occasionally: Occasionnellement
+      field.CD10.option.Most_of_the_time: La plupart du temps
+      field.CD10.option.Always: Toujours
+      field.CD11.label.Is_your_work_schedule_variable: Votre horaire de travail est il variable ? Est ce que votre rythme de sommeil est changeant ?
+      field.CD11.option.Never: Jamais
+      field.CD11.option.Rarely: Rarement
+      field.CD11.option.Occasionally: Occasionnellement
+      field.CD11.option.Most_of_the_time: La plupart du temps
+      field.CD11.option.Always: Toujours
+      field.CD12.label.Are_your_legs_restless_and_or: Vos jambes sont-elles agitées et/ou inconfortable avant de dormir ?
+      field.CD12.option.Never: Jamais
+      field.CD12.option.Rarely: Rarement
+      field.CD12.option.Occasionally: Occasionnellement
+      field.CD12.option.Most_of_the_time: La plupart du temps
+      field.CD12.option.Always: Toujours
+      field.CD13.label.Have_you_been_told_that_you_are: Vous a-t-on dit que vous êtes agité ou que vous donnez des coups de pieds pendant votre sommeil ?
+      field.CD13.option.Never: Jamais
+      field.CD13.option.Rarely: Rarement
+      field.CD13.option.Occasionally: Occasionnellement
+      field.CD13.option.Most_of_the_time: La plupart du temps
+      field.CD13.option.Always: Toujours
+      field.CD14.label.Do_you_have_unusual_behaviours: Avez-vous des attitudes ou des mouvements inhabituels durant votre sommeil ?
+      field.CD14.option.Never: Jamais
+      field.CD14.option.Rarely: Rarement
+      field.CD14.option.Occasionally: Occasionnellement
+      field.CD14.option.Most_of_the_time: La plupart du temps
+      field.CD14.option.Always: Toujours
+      field.CD15.label.Do_you_snore: Est-ce que vous ronflez ?
+      field.CD15.option.Never: Jamais
+      field.CD15.option.Rarely: Rarement
+      field.CD15.option.Occasionally: Occasionnellement
+      field.CD15.option.Most_of_the_time: La plupart du temps
+      field.CD15.option.Always: Toujours
+      field.CD16.label.Have_you_been_told_that_you: Vous a-t-on dit que vous arrêtiez de respirer, que vous ronflez ou que vous vous étouffez dans votre sommeil ?
+      field.CD16.option.Never: Jamais
+      field.CD16.option.Rarely: Rarement
+      field.CD16.option.Occasionally: Occasionnellement
+      field.CD16.option.Most_of_the_time: La plupart du temps
+      field.CD16.option.Always: Toujours
+      field.CD17.label.Do_you_have_trouble_staying: Avez-vous du mal à rester éveillé durant la journée ?
+      field.CD17.option.Never: Jamais
+      field.CD17.option.Rarely: Rarement
+      field.CD17.option.Occasionally: Occasionnellement
+      field.CD17.option.Most_of_the_time: La plupart du temps
+      field.CD17.option.Always: Toujours
+      field.CD18.label.Total_score: "Score total:"
+      group.Note_to_physician._Help_with: Note au medecin. Aide à l'interprétation des résultats
+      field.CD20.label.SO1_15_Insomnia: "SO1-15: Insomnie"
+      field.CD21.label.With_a_score_of_3_4_or_5_on_any: Avec une note de 3, 4 ou 5 pour n'importe quelle question, le patient souffre probablement d'insomnie. S'ils répondent 3, 4 ou 5 pour deux éléments ou plus et présentent une déficience diurne significative en matière d'insomnie nécessite une évaluation et une gestion plus approfondies
+      field.CD22.label.SO6_9_Mental_health_disorders: "SO6-9: Troubles mentaux"
+      field.CD23.label.Scores_of_4_or_5_on_questions_6: Les notes 4 ou 5 aux questions 6 à 9 nécessitent un dépistage plus approfondi des troubles psychiatriques. Question 8 fait référence à la somatisation et peut refléter un trouble somatoforme sous-jacent qui nécessite traitement spécifique.
+      field.CD24.label.SO10_Circadian_rhythm_disorders: "SO10: Troubles du rythme circadien"
+      field.CD25.label.A_score_of_4_or_5_on_question: Une note de 4 ou 5 à la question 10 peut être un trouble du rythme circadien. Interrogatoire supplémentaire concernant le travail posté ou une préférence pour une phase de sommeil retardée.
+      field.CD26.label.SO11_12_Restless_legs_syndrome: "SO11-12: Syndrome des jambes sans repos"
+      field.CD27.label.A_score_of_4_or_5_on_question: Une note de 4 ou 5 à la question 11 ou 12 est significative et contribue probablement au symptômes d'insomnie ou de sommeil non réparateur. La question 11 fait référence au syndrome des jambes sans repos et la question 12 fait référence aux troubles périodiques du mouvement des membres.
+      field.CD28.label.SO13_Parasomnias: "SO13: Parasomnies"
+      field.CD29.label.A_score_of_2_to_5_on_question: Une note de 2 à 5 à la question 14 devrait susciter des inquiétudes, surtout si l'événement ou le mouvement est violent ou potentiellement blessant pour le patient ou son partenaire de lit.
+      field.CD30.label.SO14_16_Sleep_apnoea: "SO14-16: Apnées du sommeil"
+      field.CD31.label.A_score_of_4_or_5_on_question: Une note de 4 ou 5 à la question 14 ou 15 nécessite à elle seule une évaluation clinique plus approfondie de l'apnée du sommeil. Une note supérieure à 3 aux questions 14 et 15 ou 14 et 16 est également suspecte d'apnée du sommeil et une évaluation plus approfondie devrait être effectuée.
+      section.Dependencies: Dépendances
+      group.Tobacco: Tabac
+      field.DEP01.label.Describe_your_smoking_behaviour: "Décrivez votre comportement tabagique:"
+      field.DEP01.option.I_have_never_smoked: Je n'ai jamais fumé
+      field.DEP01.option.I_used_to_smoke_but_I_have_quit: J'ai fumé, mais j'ai arrêté
+      field.DEP01.option.I_smoke: Je fume
+      field.DEP11.label.How_many_years_ago_did_you_quit: Depuis combien d'années avez-vous arrêté de fumer?
+      field.DEP02.label.Amount_consumed: "Quantité consommée:"
+      field.DEP03.label.Duration_of_consumption_in_years: "Durée de consommation (en années):"
+      group.Alcohol: Alcool
+      field.DEP04.label.Describe_your_alcohol: "Décrivez votre consommation de boissons alcoolisées:"
+      field.DEP04.option.I_drink_alcohol: Je consomme de l'alcool
+      field.DEP04.option.I_have_never_consumed_alcohol: Je n'ai jamais consommé d'alcool
+      field.DEP04.option.I_used_to_drink_alcohol_but_I: Je buvais de l'alcool, mais j'ai arrêté
+      field.DEP12.label.How_many_years_ago_did_you_stop: Depuis combien d'années avez-vous arrêté de consommer de l'alcool?
+      field.DEP05.label.Amount_consumed: "Quantité consommée:"
+      field.DEP06.label.Duration_of_consumption_in_years: "Durée de consommation (en années):"
+      section.General_Practitioner: Médecin généraliste
+      field.GP01.label.Contact_with_a_general: Contacts avec un médecin généraliste
+      field.GP02.label.Here_are_some_questions_about: Voici maintenant quelques questions au sujet de l’utilisation des services de soins de santé. Attention, il s'agit toujours de l'utilisation des services de soins pour vous-même.
+      field.GP03.label.Do_you_have_a_regular_general: Avez-vous un médecin généraliste attitré ou un groupe de médecins généralistes (il peut s’agir d’une maison médicale) attitré?
+      field.GP03.option.Yes: Oui
+      field.GP03.option.No: Non
+      field.GP03.option.Don_t_know: Ne sait pas
+      field.GP04.label.The_following_questions_concern: Les questions qui suivent concernent vos consultations avec le médecin généraliste. Il s’agit  des consultations au cabinet du médecin, mais aussi des visites à domicile ou , mais aussi des conseils par téléphone.
+      field.GP05.label.When_did_you_last_see_a_general: Quand avez-vous consulté un médecin généraliste pour la dernière fois?
+      field.GP05.option.Less_than_6_months_ago: Il y a moins de 6 mois
+      field.GP05.option.More_than_6_months_ago: Il y a plus de 6 mois
+      field.GP05.option.Never: Jamais
+      field.GP05.option.Don_t_know: Ne sait pas
+  - language: en
+    translations:
+      section.Summary: Summary
+      group.Patient_Data: Patient Data
+      field.DP1.label.Name: Name
+      field.DP2.label.Gender: Gender
+      field.DP3.label.Date_of_Birth: Date of Birth
+      field.GI01.label.Weight_kg: Weight, kg
+      field.GI02.label.Height_cm: Height, cm
+      field.GI03.label.BMI_kg_m2: BMI, kg/m2
+      field.GI04.label.Waist_circumference_cm: Waist circumference, cm
+      field.GI08.label.Blood_type: Blood type
+      field.GI05.label.SBP_mmHg: SBP, mmHg
+      field.GI06.label.DBP_mmHg: DBP, mmHg
+      field.GI07.label.HR_bpm: HR, bpm
+      field.GI10.label.HDL_mmol_l: HDL, mmol/l
+      field.GI11.label.CV_Score: CV Score
+      group.Medical_Summary: Medical Summary
+      field.RM1.label.Chronic_treatments: Chronic treatments
+      field.RM2.label.Allergies: Allergies
+      field.RM3.label.Medical_history: Medical history
+      field.RM4.label.Surgical_history: Surgical history
+      field.RM5.label.Family_history: Family history
+      group.Recommendations: Recommendations
+      field.RE01.label.General_health_status: General health status
+      field.RE02.label.Social_and_environmental_context: Social and environmental context
+      field.RE03.label.Mental_health: Mental health
+      field.RE03B.label.Sleep_quality: Sleep quality
+      field.RE04.label.Nutrition_and_physical_activity: Nutrition and physical activity
+      field.RE05.label.Alcohol_consumption_and: Alcohol consumption and addictions
+      field.RE06.label.Quality_and_life_expectancy: Quality and life expectancy
+      field.RE07.label.Health_journey: Health journey
+      field.RE08.label.Blood_test_results: Blood test results
+      field.RE09.label.Conclusion._Key_recommendations: Conclusion. Key recommendations
+      section.General_Information: General Information
+      field.GI01.label.Weight_kg_2: Weight, kg
+      field.GI02.label.Height_cm_2: Height, cm
+      field.GI03.label.BMI_kg_m2_2: BMI, kg/m2
+      field.GI04.label.Waist_circumference_cm_2: Waist circumference, cm
+      field.GI05.label.Blood_pressure_systolic_mmHg: Blood pressure (systolic), mmHg
+      field.GI06.label.Blood_pressure_diastolic_mmHg: Blood pressure (diastolic), mmHg
+      field.GI07.label.Heart_rate_bpm: Heart rate, bpm
+      field.GI08.label.Blood_type_2: Blood type
+      field.GI09.label.How_many_children_do_you_have: How many children do you have
+      field.MS1.label.STD_screening: STD screening
+      field.CP1.label.Patient_comment: Patient comment
+      section.Caregiver: Caregiver
+      field.IC01.label.Do_you_at_least_once_a_week: Do you, at least once a week, outside your profession, provide help or care to one or more people with age-related problems, a chronic illness, a long-term condition, or a disability?
+      field.IC01.option.Yes: Yes
+      field.IC01.option.No: No
+      field.IC02.label.Outside_your_profession_to_whom: Outside your profession, to whom do you provide the most help or care? (only one answer possible)
+      field.IC02.option.One_or_more_household_member_s: One or more household member(s)
+      field.IC02.option.One_or_more_family_member_s_but: One or more family member(s) but not household member(s)
+      field.IC02.option.One_or_more_persons_not: One or more persons, not household or family member(s)
+      field.IC03.label.In_total_how_many_hours_per: In total, how many hours per week do you generally spend providing help or care?
+      field.IC03.option.Less_than_10_hours_per_week: Less than 10 hours per week
+      field.IC03.option.At_least_10_hours_but_less_than: At least 10 hours, but less than 20 hours per week
+      field.IC03.option.20_hours_per_week_or_more: 20 hours per week or more
+      section.Social_Life: Social Life
+      field.SO01.label.How_would_you_overall_describe: How would you overall describe your social contacts (family, friends, social circle)?
+      field.SO01.option.Very_satisfying: Very satisfying
+      field.SO01.option.Rather_satisfying: Rather satisfying
+      field.SO01.option.Rather_unsatisfying: Rather unsatisfying
+      field.SO01.option.Really_unsatisfying: Really unsatisfying
+      field.SO03.label.How_many_people_are_close: How many people are close enough to you that you can count on them in case of serious difficulties?
+      field.SO03.option.None: None
+      field.SO03.option.1_or_2: 1 or 2
+      field.SO03.option.3_to_5: 3 to 5
+      field.SO03.option.6_or_more: 6 or more
+      section.Environmental_Factors: Environmental Factors
+      field.HE01.label.I_will_now_ask_you_2_sets_of: I will now ask you 2 sets of questions about environmental factors. The first set concerns environmental factors in your neighbourhood, while the second concerns factors that may affect you at home.
+      group.Series_1_Neighbourhood: "Series 1: Neighbourhood"
+      field.HE03.label.In_your_neighbourhood_to_what: In your neighbourhood, to what extent do the following conditions pose a problem?
+      field.HE04.label.Is_traffic_speed_or_volume_a: Is traffic speed or volume a problem?
+      field.HE04.option.Not_a_problem_at_all: Not a problem at all
+      field.HE04.option.Minor_problem: Minor problem
+      field.HE04.option.Fairly_big_problem: Fairly big problem
+      field.HE04.option.Very_big_problem: Very big problem
+      field.HE04.option.Don_t_know: Don't know
+      field.HE04.option.No_answer: No answer
+      field.HE07.label.Does_lack_of_access_to_parks_or: Does lack of access to parks or other green or recreational public spaces pose a problem?
+      field.HE07.option.Not_a_problem_at_all: Not a problem at all
+      field.HE07.option.Minor_problem: Minor problem
+      field.HE07.option.Fairly_big_problem: Fairly big problem
+      field.HE07.option.Very_big_problem: Very big problem
+      field.HE07.option.Don_t_know: Don't know
+      field.HE07.option.No_answer: No answer
+      group.Series_2_Home: "Series 2: Home"
+      field.HE09.label.Thinking_about_the_last_12: Thinking about the last 12 months, when you are at home, how are you bothered, affected, or annoyed by the following conditions?
+      field.HE10.label.Does_air_pollution_pose_a: Does air pollution pose a problem?
+      field.HE10.option.Not_at_all: Not at all
+      field.HE10.option.Slightly: Slightly
+      field.HE10.option.Moderately: Moderately
+      field.HE10.option.A_lot: A lot
+      field.HE10.option.Extremely: Extremely
+      field.HE10.option.Don_t_know: Don't know
+      field.HE10.option.No_answer: No answer
+      field.HE13.label.Is_traffic_noise_a_problem_road: Is traffic noise a problem? (road, train, tram, metro, plane)
+      field.HE13.option.Not_at_all: Not at all
+      field.HE13.option.Slightly: Slightly
+      field.HE13.option.Moderately: Moderately
+      field.HE13.option.A_lot: A lot
+      field.HE13.option.Extremely: Extremely
+      field.HE13.option.Don_t_know: Don't know
+      field.HE13.option.No_answer: No answer
+      field.HE16.label.Does_noise_from_nearby: Does noise from nearby businesses (factory, workshop) pose a problem?
+      field.HE16.option.Not_at_all: Not at all
+      field.HE16.option.Slightly: Slightly
+      field.HE16.option.Moderately: Moderately
+      field.HE16.option.A_lot: A lot
+      field.HE16.option.Extremely: Extremely
+      field.HE16.option.Don_t_know: Don't know
+      field.HE16.option.No_answer: No answer
+      section.Work_Absence: Work Absence
+      field.AW01.label.In_the_past_12_months_were_you: In the past 12 months, were you absent from work for health reasons? (any illness, injury, or health problem resulting in absence)
+      field.AW01.option.Yes: Yes
+      field.AW01.option.No: No
+      field.AW02.label.In_the_past_12_months_how_many: In the past 12 months, how many days in total were you absent from work for health reasons? If you don't know the exact number of days, give an estimate.
+      field.AW03.label.What_is_the_main_reason_for: What is the main reason for this absence?
+      field.AW03.option.Physical_health_problem: Physical health problem
+      field.AW03.option.Fatigue_stress_or_burnout: Fatigue, stress, or burnout
+      field.AW03.option.Accident_or_injury: Accident or injury
+      field.AW03.option.Other_reason: Other reason
+      field.AW03.option.I_prefer_not_to_answer: I prefer not to answer
+      section.Medical_History: Medical History
+      group.Cardiovascular_history: Cardiovascular history
+      field.CV00.label.The_following_questions_concern: The following questions concern your cardiovascular health (heart and blood vessels).
+      field.CV01.label.Has_a_doctor_ever_diagnosed_you: Has a doctor ever diagnosed you with one or more of the following conditions? (Multiple answers possible)
+      field.CV01.option.High_blood_pressure: High blood pressure
+      field.CV01.option.Coronary_artery_disease_angina: Coronary artery disease / angina
+      field.CV01.option.Myocardial_infarction: Myocardial infarction
+      field.CV01.option.Heart_rhythm_disorder_e.g.: Heart rhythm disorder (e.g. atrial fibrillation)
+      field.CV01.option.Heart_failure: Heart failure
+      field.CV01.option.Stroke_CVA_or_TIA: Stroke (CVA) or TIA
+      field.CV01.option.Peripheral_artery_disease: Peripheral artery disease
+      field.CV01.option.Other_cardiovascular_disease: Other cardiovascular disease
+      field.CV01.option.None: None
+      field.CV01.option.I_don_t_know: I don't know
+      field.CV02.label.Are_you_currently_taking: Are you currently taking medication for your heart or blood pressure?
+      field.CV02.option.Yes: Yes
+      field.CV02.option.No: No
+      field.CV02.option.I_don_t_know: I don't know
+      field.CV03.label.In_recent_months_have_you: In recent months, have you regularly experienced one or more of the following symptoms? (Multiple answers possible)
+      field.CV03.option.Unusual_shortness_of_breath_on: Unusual shortness of breath on exertion
+      field.CV03.option.Chest_pain_or_tightness: Chest pain or tightness
+      field.CV03.option.Palpitations_or_irregular: Palpitations or irregular heartbeat
+      field.CV03.option.Dizziness_faintness_or_loss_of: Dizziness, faintness, or loss of consciousness
+      field.CV03.option.Swelling_of_ankles_or_legs: Swelling of ankles or legs
+      field.CV03.option.None_of_these_symptoms: None of these symptoms
+      field.CV04.label.Are_you_currently_being: Are you currently being monitored by a doctor for your heart or blood pressure?
+      field.CV04.option.Yes: Yes
+      field.CV04.option.No: No
+      field.CV04.option.I_don_t_know: I don't know
+      group.Metabolic_Endocrine_history: Metabolic / Endocrine history
+      field.EN00.label.The_following_questions_concern: The following questions concern your metabolism (blood sugar, cholesterol, hormones).
+      field.EN01.label.Has_a_doctor_ever_diagnosed_you: Has a doctor ever diagnosed you with one or more of the following conditions? (Multiple answers possible)
+      field.EN01.option.Type_2_diabetes: Type 2 diabetes
+      field.EN01.option.Type_1_diabetes: Type 1 diabetes
+      field.EN01.option.Prediabetes_glucose_intolerance: Prediabetes / glucose intolerance
+      field.EN01.option.High_cholesterol_dyslipidaemia: High cholesterol (dyslipidaemia)
+      field.EN01.option.Thyroid_disease_hypo_or: Thyroid disease (hypo- or hyperthyroidism)
+      field.EN01.option.Metabolic_syndrome: Metabolic syndrome
+      field.EN01.option.Other_metabolic_or_endocrine: Other metabolic or endocrine disease
+      field.EN01.option.None: None
+      field.EN01.option.I_don_t_know: I don't know
+      field.EN02.label.Are_you_currently_being: Are you currently being monitored by a doctor for a metabolic issue (blood sugar, cholesterol, thyroid, hormones)?
+      field.EN02.option.Yes: Yes
+      field.EN02.option.No: No
+      field.EN02.option.I_don_t_know: I don't know
+      group.Respiratory_history: Respiratory history
+      field.RS00.label.The_following_questions_concern: The following questions concern your respiratory health.
+      field.RS01.label.Have_you_ever_been_diagnosed_by: Have you ever been diagnosed by a doctor with a respiratory disease?
+      field.RS01.option.Yes: Yes
+      field.RS01.option.No: No
+      field.RS01.option.I_don_t_know_I_m_not_sure: I don't know / I'm not sure
+      field.RS02.label.What_respiratory_diagnosis: What respiratory diagnosis/diagnoses have you been given by a doctor? (Multiple answers possible)
+      field.RS02.option.Asthma_current: Asthma (current)
+      field.RS02.option.Childhood_past_asthma: Childhood / past asthma
+      field.RS02.option.Chronic_obstructive_pulmonary: "Chronic obstructive pulmonary disease (COPD: chronic bronchitis and/or emphysema)"
+      field.RS02.option.Recurrent_bronchitis: Recurrent bronchitis
+      field.RS02.option.Pulmonary_fibrosis: Pulmonary fibrosis
+      field.RS02.option.Sarcoidosis: Sarcoidosis
+      field.RS02.option.Allergic_alveolitis: Allergic alveolitis
+      field.RS02.option.Cystic_fibrosis: Cystic fibrosis
+      field.RS02.option.Other_diagnosed_respiratory: Other diagnosed respiratory disease (specify)
+      field.RS02.option.I_don_t_know_the_exact_diagnosis: I don't know the exact diagnosis
+      field.RS03.label.Are_you_currently_being_treated: Are you currently being treated for a respiratory problem? (Multiple answers possible)
+      field.RS03.option.Inhaler_spray_e.g.: Inhaler / spray (e.g. bronchodilator, inhaled corticosteroid)
+      field.RS03.option.Night_time_ventilation_CPAP: Night-time ventilation (CPAP)
+      field.RS03.option.Home_oxygen_therapy: Home oxygen therapy
+      field.RS03.option.Other_respiratory_treatment: Other respiratory treatment
+      field.RS03.option.No_respiratory_treatment: No respiratory treatment
+      field.RS04.label.Do_you_currently_have_one_or: Do you currently have one or more of the following symptoms? (Multiple answers possible)
+      field.RS04.option.Shortness_of_breath_on_exertion: Shortness of breath on exertion or at rest
+      field.RS04.option.Wheezing: Wheezing
+      field.RS04.option.Chronic_cough: Chronic cough
+      field.RS04.option.Persistent_fatigue_possibly: Persistent fatigue possibly related to breathing
+      field.RS04.option.Significant_snoring: Significant snoring
+      field.RS04.option.No_respiratory_symptoms: No respiratory symptoms
+      group.Musculoskeletal_history: Musculoskeletal history
+      field.MQ00.label.The_following_questions_concern: The following questions concern your musculoskeletal system (back, joints, muscles, tendons).
+      field.MQ01.label.Has_a_doctor_ever_diagnosed_you: Has a doctor ever diagnosed you with one or more of the following conditions? (Multiple answers possible)
+      field.MQ01.option.Chronic_low_back_pain_herniated: Chronic low back pain / herniated disc / sciatica
+      field.MQ01.option.Chronic_neck_pain: Chronic neck pain
+      field.MQ01.option.Osteoarthritis_hip_knee_spine: Osteoarthritis (hip, knee, spine, other)
+      field.MQ01.option.Chronic_tendinitis_shoulder: Chronic tendinitis (shoulder, elbow, wrist, other)
+      field.MQ01.option.Carpal_tunnel_syndrome: Carpal tunnel syndrome
+      field.MQ01.option.Work_related_musculoskeletal: Work-related musculoskeletal disorder (recognised)
+      field.MQ01.option.Other_musculoskeletal_condition: Other musculoskeletal condition
+      field.MQ01.option.None: None
+      field.MQ01.option.I_don_t_know: I don't know
+      field.MQ02.label.Are_you_currently_being_treated: Are you currently being treated for a musculoskeletal problem? (doctor, physiotherapist, rheumatologist, osteopath, etc.)
+      field.MQ02.option.Yes: Yes
+      field.MQ02.option.No: No
+      field.MQ02.option.I_don_t_know: I don't know
+      field.MQ03.label.In_recent_months_have_you: In recent months, have you regularly experienced one or more of the following symptoms? (Multiple answers possible)
+      field.MQ03.option.Back_or_neck_pain: Back or neck pain
+      field.MQ03.option.Shoulder_arm_or_wrist_pain: Shoulder, arm, or wrist pain
+      field.MQ03.option.Hip_knee_or_ankle_pain: Hip, knee, or ankle pain
+      field.MQ03.option.Prolonged_joint_stiffness: Prolonged joint stiffness
+      field.MQ03.option.Decreased_mobility_or_strength: Decreased mobility or strength
+      field.MQ03.option.None_of_these_symptoms: None of these symptoms
+      field.MQ04.label.Do_these_pains_or_limitations: Do these pains or limitations impact your daily life or work?
+      field.MQ04.option.Not_at_all: Not at all
+      field.MQ04.option.A_little: A little
+      field.MQ04.option.A_lot: A lot
+      field.MQ04.option.Not_applicable_no_pain: Not applicable (no pain)
+      group.Neurological_history: Neurological history
+      field.NE00.label.The_following_questions_concern: The following questions concern your neurological system (brain, nerves, balance).
+      field.NE01.label.Has_a_doctor_ever_diagnosed_you: Has a doctor ever diagnosed you with one or more of the following conditions? (Multiple answers possible)
+      field.NE01.option.Chronic_migraine: Chronic migraine
+      field.NE01.option.Epilepsy: Epilepsy
+      field.NE01.option.Multiple_sclerosis: Multiple sclerosis
+      field.NE01.option.Parkinson_s_disease: Parkinson's disease
+      field.NE01.option.Peripheral_neuropathy_tingling: Peripheral neuropathy (tingling, loss of sensation...)
+      field.NE01.option.Neurological_disorder_following: Neurological disorder following a stroke
+      field.NE01.option.Other_neurological_disease: Other neurological disease
+      field.NE01.option.None: None
+      field.NE01.option.I_don_t_know: I don't know
+      field.NE02.label.Are_you_currently_being: Are you currently being monitored by a doctor for a neurological problem?
+      field.NE02.option.Yes: Yes
+      field.NE02.option.No: No
+      field.NE02.option.I_don_t_know: I don't know
+      field.NE03.label.In_recent_months_have_you: In recent months, have you regularly experienced one or more of the following symptoms that are NOT explained by a known neurological diagnosis? (Multiple answers possible)
+      field.NE03.option.Frequent_or_unusual_headaches: Frequent or unusual headaches
+      field.NE03.option.Dizziness_or_balance_problems: Dizziness or balance problems
+      field.NE03.option.Numbness_tingling_or_loss_of: Numbness, tingling, or loss of sensation
+      field.NE03.option.Unexplained_muscle_weakness: Unexplained muscle weakness
+      field.NE03.option.Concentration_or_memory_problems: Concentration or memory problems
+      field.NE03.option.Unusual_tremors: Unusual tremors
+      field.NE03.option.None_of_these_symptoms: None of these symptoms
+      field.NE04.label.Do_these_symptoms_impact_your: Do these symptoms impact your daily life or work?
+      field.NE04.option.Not_at_all: Not at all
+      field.NE04.option.A_little: A little
+      field.NE04.option.A_lot: A lot
+      field.NE04.option.Not_applicable_no_symptoms: Not applicable (no symptoms)
+      group.Digestive_hepatic_history: Digestive / hepatic history
+      field.DG00.label.The_following_questions_concern: The following questions concern your digestive system and liver.
+      field.DG01.label.Has_a_doctor_ever_diagnosed_you: Has a doctor ever diagnosed you with one or more of the following conditions? (Multiple answers possible)
+      field.DG01.option.Gastroesophageal_reflux_disease: Gastroesophageal reflux disease (GERD)
+      field.DG01.option.Stomach_or_duodenal_ulcer: Stomach or duodenal ulcer
+      field.DG01.option.Irritable_bowel_syndrome_IBS: Irritable bowel syndrome (IBS)
+      field.DG01.option.Inflammatory_bowel_disease: Inflammatory bowel disease (Crohn's, ulcerative colitis)
+      field.DG01.option.Liver_disease_fatty_liver: Liver disease (fatty liver, chronic hepatitis, cirrhosis...)
+      field.DG01.option.Digestive_polyps_or_history_of: Digestive polyps or history of digestive cancer
+      field.DG01.option.Other_digestive_or_liver_disease: Other digestive or liver disease
+      field.DG01.option.None: None
+      field.DG01.option.I_don_t_know: I don't know
+      field.DG02.label.Are_you_currently_being: Are you currently being monitored by a doctor for a digestive or liver problem?
+      field.DG02.option.Yes: Yes
+      field.DG02.option.No: No
+      field.DG02.option.I_don_t_know: I don't know
+      field.DG03.label.In_recent_months_have_you: In recent months, have you regularly experienced one or more of the following symptoms that are NOT explained by a known digestive diagnosis? (Multiple answers possible)
+      field.DG03.option.Heartburn_or_acid_reflux: Heartburn or acid reflux
+      field.DG03.option.Recurrent_abdominal_pain: Recurrent abdominal pain
+      field.DG03.option.Significant_bloating_or: Significant bloating or frequent digestive discomfort
+      field.DG03.option.Bowel_irregularities_persistent: Bowel irregularities (persistent diarrhoea or constipation)
+      field.DG03.option.Frequent_nausea: Frequent nausea
+      field.DG03.option.Unusual_stools_colour_appearance: Unusual stools (colour, appearance)
+      field.DG03.option.None_of_these_symptoms: None of these symptoms
+      field.DG04.label.Do_these_digestive_issues: Do these digestive issues impact your daily life or work?
+      field.DG04.option.Not_at_all: Not at all
+      field.DG04.option.A_little: A little
+      field.DG04.option.A_lot: A lot
+      field.DG04.option.Not_applicable_no_symptoms: Not applicable (no symptoms)
+      group.Urinary_history: Urinary history
+      field.UR00.label.The_following_questions_concern: The following questions concern your kidneys and urinary system.
+      field.UR01.label.Has_a_doctor_ever_diagnosed_you: Has a doctor ever diagnosed you with a kidney or urinary tract disease? (Multiple answers possible)
+      field.UR01.option.Chronic_kidney_disease: Chronic kidney disease
+      field.UR01.option.Recurrent_kidney_stones: Recurrent kidney stones
+      field.UR01.option.Recurrent_urinary_tract: Recurrent urinary tract infections
+      field.UR01.option.Chronic_kidney_or_urinary: Chronic kidney or urinary disease (other)
+      field.UR01.option.None: None
+      field.UR01.option.I_don_t_know: I don't know
+      field.UR02.label.Are_you_currently_being: Are you currently being monitored by a doctor for a kidney or urinary problem?
+      field.UR02.option.Yes: Yes
+      field.UR02.option.No: No
+      field.UR02.option.I_don_t_know: I don't know
+      field.UR03.label.In_recent_months_have_you: In recent months, have you regularly had one or more of the following symptoms that are NOT explained by a known urinary or kidney diagnosis? (Multiple answers possible)
+      field.UR03.option.Frequent_need_to_urinate: Frequent need to urinate
+      field.UR03.option.Night_time_urination_nocturia: Night-time urination (nocturia)
+      field.UR03.option.Pain_or_burning_during_urination: Pain or burning during urination
+      field.UR03.option.Difficulty_completely_emptying: Difficulty completely emptying the bladder
+      field.UR03.option.Unexplained_lower_back_pain: Unexplained lower back pain
+      field.UR03.option.None_of_these_symptoms: None of these symptoms
+      field.UR04.label.Do_these_urinary_issues_impact: Do these urinary issues impact your sleep, daily life, or work?
+      field.UR04.option.Not_at_all: Not at all
+      field.UR04.option.A_little: A little
+      field.UR04.option.A_lot: A lot
+      field.UR04.option.Not_applicable_no_symptoms: Not applicable (no symptoms)
+      group.Personal_history_of_cancer: Personal history of cancer
+      field.CA00.label.The_following_questions_concern: The following questions concern your personal history of cancer.
+      field.CA01.label.Has_a_doctor_ever_diagnosed_you: Has a doctor ever diagnosed you with cancer, currently or in the past (even if you are cured)?
+      field.CA01.option.Yes: Yes
+      field.CA01.option.No: No
+      field.CA01.option.I_don_t_know: I don't know
+      field.CA02.label.What_type_of_cancer_Multiple: What type of cancer? (Multiple answers possible)
+      field.CA02.option.Breast: Breast
+      field.CA02.option.Prostate: Prostate
+      field.CA02.option.Lung: Lung
+      field.CA02.option.Colorectal: Colorectal
+      field.CA02.option.Skin: Skin
+      field.CA02.option.Gynaecological: Gynaecological
+      field.CA02.option.Other_specify: Other (specify)
+      field.CA02_PRECISION.label.Specify_the_type_of_cancer: Specify the type of cancer
+      group.Other_medical_history: Other medical history
+      field.OT00.label.The_following_questions_concern: The following questions concern any other medical history.
+      field.OT01.label.Apart_from_what_has_already: "Apart from what has already been covered in this questionnaire, do you have another chronic health problem or significant medical history that impacts your daily life or work? (For example: ophthalmological, gynaecological, ENT, dermatological, other)"
+      field.OT01.option.Yes: Yes
+      field.OT01.option.No: No
+      field.OT02.label.Can_you_specify_in_a_few_words: Can you specify in a few words? (Free text field - optional)
+      field.OT03.label.Do_these_issues_impact_your: Do these issues impact your daily life or work?
+      field.OT03.option.Not_at_all: Not at all
+      field.OT03.option.A_little: A little
+      field.OT03.option.A_lot: A lot
+      field.OT03.option.Not_applicable_no_symptoms: Not applicable (no symptoms)
+      field.OT04.label.Are_you_generally_up_to_date: Are you generally up to date with your recommended adult vaccinations (according to your doctor)?
+      field.OT04.option.Yes: Yes
+      field.OT04.option.No: No
+      field.OT04.option.I_don_t_know: I don't know
+      field.OT05.label.When_did_you_last_have_your: When did you last have your eyesight checked by an ophthalmologist?
+      field.OT05.option.Less_than_1_year_ago: Less than 1 year ago
+      field.OT05.option.1_to_2_years_ago: 1 to 2 years ago
+      field.OT05.option.More_than_2_years_ago: More than 2 years ago
+      field.OT05.option.I_have_never_had_a_check_up: I have never had a check-up
+      field.OT05.option.I_don_t_remember: I don't remember
+      field.OT06.label.Have_you_ever_had_a_major: Have you ever had a major surgery in your life?
+      field.OT06.option.Yes: Yes
+      field.OT06.option.No: No
+      field.OT06.option.I_don_t_remember: I don't remember
+      field.OT07.label.Which_one_if_you_remember: Which one (if you remember)?
+      group.Family_history: Family history
+      field.FA00.label.The_following_questions_concern: The following questions concern certain diseases that may exist in your close family (parents, siblings).
+      field.FA01.label.Has_a_close_family_member_had: Has a close family member had cardiovascular disease (heart attack, stroke, sudden death) at an early age?
+      field.FA01.option.Yes: Yes
+      field.FA01.option.No: No
+      field.FA01.option.I_don_t_know: I don't know
+      field.FA02.label.Is_there_a_history_of_cancer_in: Is there a history of cancer in your close family (breast, ovarian, prostate, colorectal, pancreatic)?
+      field.FA02.option.Yes: Yes
+      field.FA02.option.No: No
+      field.FA02.option.I_don_t_know: I don't know
+      field.FA03.label.Do_close_family_members_have: Do close family members have type 2 diabetes?
+      field.FA03.option.Yes: Yes
+      field.FA03.option.No: No
+      field.FA03.option.I_don_t_know: I don't know
+      section.Dental_Health: Dental Health
+      field.DHDC01.label.How_often_do_you_usually_brush: How often do you usually brush your teeth?
+      field.DHDC01.option.More_than_twice_a_day: More than twice a day
+      field.DHDC01.option.Twice_a_day: Twice a day
+      field.DHDC01.option.Once_a_day: Once a day
+      field.DHDC01.option.Less_than_once_a_day: Less than once a day
+      field.DHDC01.option.Never: Never
+      field.DHDC01.option.Not_applicable_according_to: Not applicable (according to respondent)
+      field.DHDC02.label.Overall_how_would_you_rate_the: Overall, how would you rate the condition of your teeth and gums?
+      field.DHDC02.option.Very_good: Very good
+      field.DHDC02.option.Good: Good
+      field.DHDC02.option.Neither_good_nor_bad: Neither good nor bad
+      field.DHDC02.option.Bad: Bad
+      field.DHDC02.option.Very_bad: Very bad
+      field.DHDC03.label.In_the_past_12_months_have_you: In the past 12 months, have you had pain in your mouth?
+      field.DHDC03.option.Yes: Yes
+      field.DHDC03.option.No: No
+      field.DHDC04.label.When_did_you_last_visit_your: When did you last visit your dentist or orthodontist?
+      field.DHDC04.option.Less_than_6_months_ago: Less than 6 months ago
+      field.DHDC04.option.6_months_or_more_ago_but_less: 6 months or more ago, but less than 12 months.
+      field.DHDC04.option.12_months_or_more_ago: 12 months or more ago
+      field.DHDC04.option.Never: Never
+      field.DHDC04.option.Don_t_know: Don't know
+      section.Cancer_Screening: Cancer Screening
+      group.Family_history_of_cancer: Family history of cancer
+      field.SC02.label.Is_there_a_history_of_cancer_in: Is there a history of cancer in your close family (breast, ovarian, prostate, colorectal, pancreatic)?
+      field.SC02.option.Yes: Yes
+      field.SC02.option.No: No
+      field.SC02.option.I_don_t_know: I don't know
+      group.Prostate_cancer.: Prostate cancer.
+      field.SC20.label.IPSS_International_Prostate: "IPSS: International Prostate Symptom Score"
+      field.SC21.label.In_the_past_month_how_often: In the past month, how often have you had the feeling that your bladder was not completely emptied after urinating?
+      field.SC21.option.Never: Never
+      field.SC21.option.About_1_time_in_5: About 1 time in 5
+      field.SC21.option.About_1_time_in_3: About 1 time in 3
+      field.SC21.option.About_1_time_in_2: About 1 time in 2
+      field.SC21.option.About_2_times_in_3: About 2 times in 3
+      field.SC21.option.Almost_always: Almost always
+      field.SC22.label.In_the_past_month_how_often: In the past month, how often have you needed to urinate less than 2 hours after finishing urinating?
+      field.SC22.option.Never: Never
+      field.SC22.option.About_1_time_in_5: About 1 time in 5
+      field.SC22.option.About_1_time_in_3: About 1 time in 3
+      field.SC22.option.About_1_time_in_2: About 1 time in 2
+      field.SC22.option.About_2_times_in_3: About 2 times in 3
+      field.SC22.option.Almost_always: Almost always
+      field.SC23.label.In_the_past_month_how_often: In the past month, how often have you had an interrupted urine stream, i.e. starting to urinate then stopping then restarting?
+      field.SC23.option.Never: Never
+      field.SC23.option.About_1_time_in_5: About 1 time in 5
+      field.SC23.option.About_1_time_in_3: About 1 time in 3
+      field.SC23.option.About_1_time_in_2: About 1 time in 2
+      field.SC23.option.About_2_times_in_3: About 2 times in 3
+      field.SC23.option.Almost_always: Almost always
+      field.SC24.label.In_the_past_month_after_feeling: In the past month, after feeling the need to urinate, how often have you had difficulty holding back?
+      field.SC24.option.Never: Never
+      field.SC24.option.About_1_time_in_5: About 1 time in 5
+      field.SC24.option.About_1_time_in_3: About 1 time in 3
+      field.SC24.option.About_1_time_in_2: About 1 time in 2
+      field.SC24.option.About_2_times_in_3: About 2 times in 3
+      field.SC24.option.Almost_always: Almost always
+      field.SC25.label.In_the_past_month_how_often: In the past month, how often have you had a weak or reduced urine stream?
+      field.SC25.option.Never: Never
+      field.SC25.option.About_1_time_in_5: About 1 time in 5
+      field.SC25.option.About_1_time_in_3: About 1 time in 3
+      field.SC25.option.About_1_time_in_2: About 1 time in 2
+      field.SC25.option.About_2_times_in_3: About 2 times in 3
+      field.SC25.option.Almost_always: Almost always
+      field.SC26.label.In_the_past_month_how_often: In the past month, how often have you had to push or strain to begin urinating?
+      field.SC26.option.Never: Never
+      field.SC26.option.About_1_time_in_5: About 1 time in 5
+      field.SC26.option.About_1_time_in_3: About 1 time in 3
+      field.SC26.option.About_1_time_in_2: About 1 time in 2
+      field.SC26.option.About_2_times_in_3: About 2 times in 3
+      field.SC26.option.Almost_always: Almost always
+      field.SC27.label.In_the_past_month_how_many: In the past month, how many times per night on average did you get up to urinate (between going to bed and getting up in the morning)?
+      field.SC27.option.Never: Never
+      field.SC27.option.1_time: 1 time
+      field.SC27.option.2_times: 2 times
+      field.SC27.option.3_times: 3 times
+      field.SC27.option.4_times: 4 times
+      field.SC27.option.5_times: 5 times
+      field.SC28.label.Total_score: "Total score:"
+      field.SC29.label.IPSS_notes_0_7_mild_8_19: "IPSS notes: 0 – 7 = mild; 8 – 19 = moderate; 20 – 35 = severe"
+      group.Colorectal_cancer_screening: "Colorectal cancer screening:"
+      field.SC31.label.There_is_a_screening_test_for: There is a screening test for bowel (colorectal) cancer that detects the presence of blood in the stool. Have you ever had this type of test?
+      field.SC31.option.Yes: Yes
+      field.SC31.option.No: No
+      field.SC32.label.When_did_you_last_have_a_test: When did you last have a test to detect blood in the stool?
+      field.SC32.option.Less_than_2_years_ago: Less than 2 years ago
+      field.SC32.option.2_years_or_more_ago: 2 years or more ago
+      field.SC32.option.Never: Never
+      field.SC32.option.I_don_t_know: I don't know
+      field.SC33.label.A_more_thorough_examination: A more thorough examination involves an internal examination (endoscopy) of the bowel using a probe. This is called a "colonoscopy". Have you ever had a colonoscopy?
+      field.SC33.option.Yes: Yes
+      field.SC33.option.No: No
+      field.SC34.label.When_did_you_last_have_a: When did you last have a colonoscopy?
+      field.SC34.option.Less_than_5_years_ago: Less than 5 years ago
+      field.SC34.option.More_than_5_years_ago_but_less: More than 5 years ago but less than 10 years
+      field.SC34.option.More_than_10_years_ago: More than 10 years ago
+      group.Breast_cancer_screening: "Breast cancer screening:"
+      field.SC36.label.Have_you_ever_had_a_mammography: Have you ever had a mammography (X-ray of one or both breasts)?
+      field.SC36.option.Yes: Yes
+      field.SC36.option.No: No
+      field.SC36.option.I_don_t_know: I don't know
+      field.SC37.label.When_did_you_last_have_a: When did you last have a mammography?
+      field.SC37.option.Less_than_2_years_ago: Less than 2 years ago
+      field.SC37.option.2_years_or_more_ago: 2 years or more ago
+      field.SC37.option.I_don_t_know: I don't know
+      group.Cervical_cancer_screening: "Cervical cancer screening:"
+      field.SC39.label.Have_you_ever_had_a_cervical: Have you ever had a cervical smear test (Pap smear)?
+      field.SC39.option.Yes: Yes
+      field.SC39.option.No: No
+      field.SC40.label.When_did_you_last_have_a: When did you last have a cervical smear test?
+      field.SC40.option.Less_than_3_years_ago: Less than 3 years ago
+      field.SC40.option.3_years_or_more_ago: 3 years or more ago
+      field.SC40.option.I_don_t_know: I don't know
+      group.Skin_cancer: Skin cancer
+      field.SC42.label.Do_you_have_more_than_50_moles: Do you have more than 50 moles on your body?
+      field.SC42.option.Yes: Yes
+      field.SC42.option.No: No
+      field.SC42.option.I_don_t_know: I don't know
+      field.SC44.label.How_does_your_skin_generally: How does your skin generally react to the sun?
+      field.SC44.option.I_burn_easily_I_tan_little_or: I burn easily, I tan little or not at all
+      field.SC44.option.I_sometimes_burn_then_tan: I sometimes burn then tan
+      field.SC44.option.I_tan_easily_and_rarely_burn: I tan easily and rarely burn
+      field.SC44.option.I_don_t_know: I don't know
+      field.SC45.label.Have_you_been_repeatedly: Have you been repeatedly heavily exposed to the sun during your life? (outdoor work, frequent outdoor leisure, prolonged stays in very sunny regions, etc.)
+      field.SC45.option.Yes: Yes
+      field.SC45.option.No: No
+      field.SC45.option.I_don_t_know: I don't know
+      field.SC46.label.Have_you_ever_used_tanning_beds: Have you ever used tanning beds (artificial UV)?
+      field.SC46.option.Never: Never
+      field.SC46.option.Occasionally: Occasionally
+      field.SC46.option.Regularly_in_the_past_or: Regularly (in the past or currently)
+      field.SC47.label.Have_you_ever_had_your_moles_or: Have you ever had your moles or skin examined by a doctor or dermatologist?
+      field.SC47.option.Yes: Yes
+      field.SC47.option.No: No
+      field.SC47.option.I_don_t_know: I don't know
+      group.Lung_cancer: Lung cancer
+      field.SC48.label.Have_you_smoked_the_equivalent: "Have you smoked the equivalent of at least one pack per day for 20 years (or more)? (or equivalent: e.g. 2 packs/day for 10 years)"
+      field.SC48.option.Yes: Yes
+      field.SC48.option.No: No
+      field.SC48.option.I_don_t_know: I don't know
+      section.Cardiovascular_Diseases: Cardiovascular Diseases
+      field.PR01.label.Has_your_blood_pressure_ever: Has your blood pressure ever been measured by a doctor, nurse, or other healthcare professional?
+      field.PR01.option.Yes: Yes
+      field.PR01.option.No: No
+      field.PR01.option.I_don_t_know: I don't know
+      field.PR03.label.If_your_blood_pressure_was: If your blood pressure was measured less than a year ago, do you remember what it was?
+      field.PR03.option.Above_140_90_mmHg: Above 140/90 mmHg
+      field.PR03.option.Between_120_70_and_140_90_mmHg: Between 120/70 and 140/90 mmHg
+      field.PR03.option.Below_120_70_mmHg: Below 120/70 mmHg
+      field.PR03.option.I_don_t_remember: I don't remember
+      field.PR04.label.When_did_you_last_have_a_blood: When did you last have a blood test?
+      field.PR04.option.Less_than_a_year_ago: Less than a year ago
+      field.PR04.option.More_than_1_year_ago: More than 1 year ago
+      field.PR04.option.I_don_t_remember: I don't remember
+      section.Physical_Pain: Physical Pain
+      field.PI02.label.Do_you_currently_experience: Do you currently experience persistent pain (for 3 months or more) that impacts your daily life or work?
+      field.PI02.option.Yes: Yes
+      field.PI02.option.No: No
+      section.Mental_Health: Mental Health
+      group.Perceived_stress: Perceived stress
+      field.SM02.label.In_the_past_month_how_often: In the past month, how often have you been upset because of something that happened unexpectedly?
+      field.SM02.option.Never: Never
+      field.SM02.option.Almost_never: Almost never
+      field.SM02.option.Sometimes: Sometimes
+      field.SM02.option.Often: Often
+      field.SM02.option.Very_often: Very often
+      field.SM03.label.In_the_past_month_how_often: In the past month, how often have you felt unable to control the important things in your life?
+      field.SM03.option.Never: Never
+      field.SM03.option.Almost_never: Almost never
+      field.SM03.option.Sometimes: Sometimes
+      field.SM03.option.Often: Often
+      field.SM03.option.Very_often: Very often
+      field.SM04.label.In_the_past_month_how_often: In the past month, how often have you felt nervous and stressed?
+      field.SM04.option.Never: Never
+      field.SM04.option.Almost_never: Almost never
+      field.SM04.option.Sometimes: Sometimes
+      field.SM04.option.Often: Often
+      field.SM04.option.Very_often: Very often
+      field.SM05.label.In_the_past_month_how_often: In the past month, how often have you felt confident in your ability to handle your personal problems?
+      field.SM05.option.Never: Never
+      field.SM05.option.Almost_never: Almost never
+      field.SM05.option.Sometimes: Sometimes
+      field.SM05.option.Often: Often
+      field.SM05.option.Very_often: Very often
+      field.SM06.label.In_the_past_month_how_often: In the past month, how often have you felt that things were going your way?
+      field.SM06.option.Never: Never
+      field.SM06.option.Almost_never: Almost never
+      field.SM06.option.Sometimes: Sometimes
+      field.SM06.option.Often: Often
+      field.SM06.option.Very_often: Very often
+      field.SM07.label.In_the_past_month_how_often: In the past month, how often have you found that you could not cope with all the things you had to do?
+      field.SM07.option.Never: Never
+      field.SM07.option.Almost_never: Almost never
+      field.SM07.option.Sometimes: Sometimes
+      field.SM07.option.Often: Often
+      field.SM07.option.Very_often: Very often
+      field.SM08.label.In_the_past_month_how_often: In the past month, how often have you been able to control irritations in your life?
+      field.SM08.option.Never: Never
+      field.SM08.option.Almost_never: Almost never
+      field.SM08.option.Sometimes: Sometimes
+      field.SM08.option.Often: Often
+      field.SM08.option.Very_often: Very often
+      field.SM09.label.In_the_past_month_how_often: In the past month, how often have you felt that you were on top of things?
+      field.SM09.option.Never: Never
+      field.SM09.option.Almost_never: Almost never
+      field.SM09.option.Sometimes: Sometimes
+      field.SM09.option.Often: Often
+      field.SM09.option.Very_often: Very often
+      field.SM10.label.In_the_past_month_how_often: In the past month, how often have you been angered because of things that were outside your control?
+      field.SM10.option.Never: Never
+      field.SM10.option.Almost_never: Almost never
+      field.SM10.option.Sometimes: Sometimes
+      field.SM10.option.Often: Often
+      field.SM10.option.Very_often: Very often
+      field.SM11.label.In_the_past_month_how_often: In the past month, how often have you felt that difficulties were piling up so high that you could not overcome them?
+      field.SM11.option.Never: Never
+      field.SM11.option.Almost_never: Almost never
+      field.SM11.option.Sometimes: Sometimes
+      field.SM11.option.Often: Often
+      field.SM11.option.Very_often: Very often
+      field.SM12.label.Total_score: "Total score:"
+      group.Overall_well_being_energy_and: Overall well-being, energy, and fatigue
+      field.SM14.label.On_a_scale_of_0_to_10_where_0: On a scale of 0 to 10, where 0 means "not at all satisfied" and 10 means "completely satisfied", how satisfied are you currently with your life?
+      field.SM15.label.In_recent_weeks_to_what_extent: In recent weeks, to what extent have you felt energetic or dynamic?
+      field.SM16.label.In_recent_weeks_to_what_extent: In recent weeks, to what extent have you felt tired or exhausted?
+      group.GAD_7_Scale_anxiety_disorder: GAD-7 Scale, anxiety disorder screening
+      field.SM35.label.Over_the_last_2_weeks_how_often: Over the last 2 weeks, how often have you been bothered by the following problems?
+      field.SM36.label.Feeling_nervous_anxious_or_on: Feeling nervous, anxious, or on edge
+      field.SM36.option.Never: Never
+      field.SM36.option.Several_days: Several days
+      field.SM36.option.More_than_half_the_days: More than half the days
+      field.SM36.option.Nearly_every_day: Nearly every day
+      field.SM37.label.Not_being_able_to_stop_or: Not being able to stop or control worrying
+      field.SM37.option.Never: Never
+      field.SM37.option.Several_days: Several days
+      field.SM37.option.More_than_half_the_days: More than half the days
+      field.SM37.option.Nearly_every_day: Nearly every day
+      field.SM38.label.Worrying_too_much_about: Worrying too much about different things
+      field.SM38.option.Never: Never
+      field.SM38.option.Several_days: Several days
+      field.SM38.option.More_than_half_the_days: More than half the days
+      field.SM38.option.Nearly_every_day: Nearly every day
+      field.SM39.label.Trouble_relaxing: Trouble relaxing
+      field.SM39.option.Never: Never
+      field.SM39.option.Several_days: Several days
+      field.SM39.option.More_than_half_the_days: More than half the days
+      field.SM39.option.Nearly_every_day: Nearly every day
+      field.SM40.label.Being_so_restless_that_it_is: Being so restless that it is hard to sit still
+      field.SM40.option.Never: Never
+      field.SM40.option.Several_days: Several days
+      field.SM40.option.More_than_half_the_days: More than half the days
+      field.SM40.option.Nearly_every_day: Nearly every day
+      field.SM41.label.Becoming_easily_annoyed_or: Becoming easily annoyed or irritable
+      field.SM41.option.Never: Never
+      field.SM41.option.Several_days: Several days
+      field.SM41.option.More_than_half_the_days: More than half the days
+      field.SM41.option.Nearly_every_day: Nearly every day
+      field.SM42.label.Feeling_afraid_as_if_something: Feeling afraid as if something awful might happen
+      field.SM42.option.Never: Never
+      field.SM42.option.Several_days: Several days
+      field.SM42.option.More_than_half_the_days: More than half the days
+      field.SM42.option.Nearly_every_day: Nearly every day
+      field.SM43.label.Total_score: "Total score:"
+      group.PHQ_9_Scale_depression_screening: PHQ-9 Scale, depression screening
+      field.SM45.label.Please_answer_each_question_by: Please answer each question by selecting the statement that best matches your situation
+      field.SM46.label.Over_the_last_two_weeks_how: Over the last two weeks, how often have you been bothered by the following problems?
+      field.SM47.label.Little_interest_or_pleasure_in: Little interest or pleasure in doing things
+      field.SM47.option.Never: Never
+      field.SM47.option.Several_days: Several days
+      field.SM47.option.More_than_half_the_days: More than half the days
+      field.SM47.option.Nearly_every_day: Nearly every day
+      field.SM48.label.Feeling_down_depressed_or: Feeling down, depressed, or hopeless
+      field.SM48.option.Never: Never
+      field.SM48.option.Several_days: Several days
+      field.SM48.option.More_than_half_the_days: More than half the days
+      field.SM48.option.Nearly_every_day: Nearly every day
+      field.SM49.label.Trouble_falling_asleep_staying: Trouble falling asleep, staying asleep, or sleeping too much
+      field.SM49.option.Never: Never
+      field.SM49.option.Several_days: Several days
+      field.SM49.option.More_than_half_the_days: More than half the days
+      field.SM49.option.Nearly_every_day: Nearly every day
+      field.SM50.label.Feeling_tired_or_having_little: Feeling tired or having little energy
+      field.SM50.option.Never: Never
+      field.SM50.option.Several_days: Several days
+      field.SM50.option.More_than_half_the_days: More than half the days
+      field.SM50.option.Nearly_every_day: Nearly every day
+      field.SM51.label.Poor_appetite_or_overeating: Poor appetite or overeating
+      field.SM51.option.Never: Never
+      field.SM51.option.Several_days: Several days
+      field.SM51.option.More_than_half_the_days: More than half the days
+      field.SM51.option.Nearly_every_day: Nearly every day
+      field.SM52.label.Feeling_bad_about_yourself_or: Feeling bad about yourself, or that you are a failure or have let yourself or your family down
+      field.SM52.option.Never: Never
+      field.SM52.option.Several_days: Several days
+      field.SM52.option.More_than_half_the_days: More than half the days
+      field.SM52.option.Nearly_every_day: Nearly every day
+      field.SM53.label.Trouble_concentrating_on_things: Trouble concentrating on things, such as reading the newspaper or watching television
+      field.SM53.option.Never: Never
+      field.SM53.option.Several_days: Several days
+      field.SM53.option.More_than_half_the_days: More than half the days
+      field.SM53.option.Nearly_every_day: Nearly every day
+      field.SM54.label.Moving_or_speaking_so_slowly: Moving or speaking so slowly that other people could have noticed. Or the opposite — being so fidgety or restless that you have been moving around a lot more than usual.
+      field.SM54.option.Never: Never
+      field.SM54.option.Several_days: Several days
+      field.SM54.option.More_than_half_the_days: More than half the days
+      field.SM54.option.Nearly_every_day: Nearly every day
+      field.SM55.label.Thoughts_that_you_would_be: Thoughts that you would be better off dead or of hurting yourself in some way.
+      field.SM55.option.Never: Never
+      field.SM55.option.Several_days: Several days
+      field.SM55.option.More_than_half_the_days: More than half the days
+      field.SM55.option.Nearly_every_day: Nearly every day
+      field.SM56.label.Total_score: "Total score:"
+      field.SM57.label.If_the_patient_answers_yes_to: If the patient answers yes to question 9, an assessment of suicide risk or self-harm by a qualified healthcare or social services professional is recommended.
+      field.SM58.label.If_you_checked_off_any_problems: "If you checked off any problems in this questionnaire, answer the following question: How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?"
+      field.SM58.option.Not_difficult_at_all: Not difficult at all
+      field.SM58.option.Somewhat_difficult: Somewhat difficult
+      field.SM58.option.Very_difficult: Very difficult
+      field.SM58.option.Extremely_difficult: Extremely difficult
+      group.Depression_and_anxiety_disorders: Depression and anxiety disorders
+      field.SM60.label.Over_the_last_2_weeks_how_often: "Over the last 2 weeks, how often have you experienced difficulties such as:"
+      field.SM61.label.Feeling_nervous_anxious_or_on: Feeling nervous, anxious, or on edge
+      field.SM61.option.Not_at_all: Not at all
+      field.SM61.option.Several_days: Several days
+      field.SM61.option.More_than_half_the_days: More than half the days
+      field.SM61.option.Nearly_every_day: Nearly every day
+      field.SM62.label.Not_being_able_to_stop_or: Not being able to stop or control worrying
+      field.SM62.option.Not_at_all: Not at all
+      field.SM62.option.Several_days: Several days
+      field.SM62.option.More_than_half_the_days: More than half the days
+      field.SM62.option.Nearly_every_day: Nearly every day
+      field.SM63.label.Worrying_too_much_about: Worrying too much about different things
+      field.SM63.option.Not_at_all: Not at all
+      field.SM63.option.Several_days: Several days
+      field.SM63.option.More_than_half_the_days: More than half the days
+      field.SM63.option.Nearly_every_day: Nearly every day
+      field.SM64.label.Having_trouble_relaxing: Having trouble relaxing
+      field.SM64.option.Not_at_all: Not at all
+      field.SM64.option.Several_days: Several days
+      field.SM64.option.More_than_half_the_days: More than half the days
+      field.SM64.option.Nearly_every_day: Nearly every day
+      field.SM65.label.Being_so_restless_that_it_is: Being so restless that it is hard to sit still
+      field.SM65.option.Not_at_all: Not at all
+      field.SM65.option.Several_days: Several days
+      field.SM65.option.More_than_half_the_days: More than half the days
+      field.SM65.option.Nearly_every_day: Nearly every day
+      field.SM66.label.Being_easily_annoyed_or: Being easily annoyed or irritable
+      field.SM66.option.Not_at_all: Not at all
+      field.SM66.option.Several_days: Several days
+      field.SM66.option.More_than_half_the_days: More than half the days
+      field.SM66.option.Nearly_every_day: Nearly every day
+      field.SM67.label.Feeling_afraid_as_if_something: Feeling afraid, as if something awful might happen
+      field.SM67.option.Not_at_all: Not at all
+      field.SM67.option.Several_days: Several days
+      field.SM67.option.More_than_half_the_days: More than half the days
+      field.SM67.option.Nearly_every_day: Nearly every day
+      section.Physical_Activity: Physical Activity
+      field.PA01.label.The_following_questions_concern: The following questions concern your physical activities during a typical week, whether at work, commuting, or during leisure.
+      group.Work_and_Daily_Activities: Work and Daily Activities
+      field.PA05.label.Generally_speaking_would_you: "Generally speaking, would you say you are physically:"
+      field.PA05.option.Very_inactive: Very inactive
+      field.PA05.option.Moderately_active: Moderately active
+      field.PA05.option.Active: Active
+      field.PA05.option.Very_active: Very active
+      group.Commuting_and_Transport: Commuting and Transport
+      field.PA08.label.In_a_typical_week_how_many_days: In a typical week, how many days do you do at least 30 minutes of moderate or vigorous physical activity? (brisk walking, cycling, sports, fitness, swimming, jogging, etc.)
+      field.PA08.option.0_days: 0 days
+      field.PA08.option.1_to_2_days: 1 to 2 days
+      field.PA08.option.3_to_4_days: 3 to 4 days
+      field.PA08.option.5_days_or_more: 5 days or more
+      field.PA09.label.Do_you_regularly_engage_in_a: Do you regularly engage in a sport or leisure activity?
+      field.PA09.option.No: No
+      field.PA09.option.Yes_occasionally: Yes, occasionally
+      field.PA09.option.Yes_1_to_2_times_per_week: Yes, 1 to 2 times per week
+      field.PA09.option.Yes_3_times_per_week_or_more: Yes, 3 times per week or more
+      field.PA10.label.In_a_typical_week_how_many_days: In a typical week, how many days do you do muscle-strengthening exercises? (weight training, core exercises, resistance exercises, etc.)
+      field.PA10.option.0_days: 0 days
+      field.PA10.option.1_day: 1 day
+      field.PA10.option.2_days: 2 days
+      field.PA10.option.3_days_or_more: 3 days or more
+      field.PA11.label.On_a_typical_day_how_much_time: On a typical day, how much time do you spend sitting or lying down (excluding sleep)? (at work, at home, in transport, in front of a screen, etc.)
+      field.PA11.option.Less_than_6_hours_per_day: Less than 6 hours per day
+      field.PA11.option.6_to_8_hours_per_day: 6 to 8 hours per day
+      field.PA11.option.8_to_10_hours_per_day: 8 to 10 hours per day
+      field.PA11.option.More_than_10_hours_per_day: More than 10 hours per day
+      field.PA12.label.Is_your_work_physically: Is your work physically demanding?
+      field.PA12.option.No_mainly_seated_or_standing: No, mainly seated or standing
+      field.PA12.option.Yes_moderately_active_walking: Yes, moderately active (walking, frequent movement)
+      field.PA12.option.Yes_physically_demanding: Yes, physically demanding
+      section.Nutritional_Habits: Nutritional Habits
+      field.NH01.label.How_often_do_you_eat_fruit: How often do you eat fruit? Fresh-squeezed juices, concentrate-based or processed fruit juices, and sweetened juices are not included
+      field.NH01.option.Every_day: Every day
+      field.NH01.option.4_to_6_times_per_week: 4 to 6 times per week
+      field.NH01.option.1_to_3_times_per_week: 1 to 3 times per week
+      field.NH01.option.Less_than_once_a_week: Less than once a week
+      field.NH01.option.Never: Never
+      field.NH02.label.How_often_do_you_eat_vegetables: How often do you eat vegetables or salad? (Excluding potatoes, soups, and juices)
+      field.NH02.option.Every_day: Every day
+      field.NH02.option.4_to_6_times_per_week: 4 to 6 times per week
+      field.NH02.option.1_to_3_times_per_week: 1 to 3 times per week
+      field.NH02.option.Less_than_once_a_week: Less than once a week
+      field.NH02.option.Never: Never
+      field.NH03.label.How_often_do_you_drink_sugary: How often do you drink sugary beverages (sodas, lemonades, iced tea, sweetened juices)? (Excluding light/zero versions)
+      field.NH03.option.Every_day: Every day
+      field.NH03.option.4_to_6_times_per_week: 4 to 6 times per week
+      field.NH03.option.1_to_3_times_per_week: 1 to 3 times per week
+      field.NH03.option.Less_than_once_a_week: Less than once a week
+      field.NH03.option.Never: Never
+      field.NH04.label.How_often_do_you_eat_sweet_or: How often do you eat sweet or salty snacks (candy, chocolate, pastries, biscuits, chips...)?
+      field.NH04.option.Every_day: Every day
+      field.NH04.option.4_to_6_times_per_week: 4 to 6 times per week
+      field.NH04.option.1_to_3_times_per_week: 1 to 3 times per week
+      field.NH04.option.Less_than_once_a_week: Less than once a week
+      field.NH04.option.Never: Never
+      field.NH05.label.On_average_how_much_water_do: On average, how much water do you drink per day (excluding coffee, tea, sodas, alcohol)?
+      field.NH05.option.Less_than_1_litre: Less than 1 litre
+      field.NH05.option.About_1_to_1.5_litres: About 1 to 1.5 litres
+      field.NH05.option.More_than_1.5_litres: More than 1.5 litres
+      field.NH05.option.I_don_t_know: I don't know
+      field.NH06.label.How_often_do_you_eat_breakfast: How often do you eat breakfast (in the morning)?
+      field.NH06.option.Every_day: Every day
+      field.NH06.option.5_to_6_times_per_week: 5 to 6 times per week
+      field.NH06.option.2_to_4_times_per_week: 2 to 4 times per week
+      field.NH06.option.Rarely: Rarely
+      field.NH06.option.Never: Never
+      field.NH07.label.Do_you_snack_between_meals: Do you snack between meals?
+      field.NH07.option.Yes_often: Yes, often
+      field.NH07.option.Yes_sometimes: Yes, sometimes
+      field.NH07.option.No_rarely: No, rarely
+      field.NH07.option.No_never: No, never
+      field.NH08.label.How_often_do_you_eat_processed: How often do you eat processed or ultra-processed foods (ready meals, deli meats, frozen pizzas, etc.)?
+      field.NH08.option.Very_often: Very often
+      field.NH08.option.Often: Often
+      field.NH08.option.Occasionally: Occasionally
+      field.NH08.option.Rarely: Rarely
+      field.NH08.option.Never: Never
+      field.NH09.label.How_often_do_you_eat_fast_food: How often do you eat fast food?
+      field.NH09.option.Several_times_per_week: Several times per week
+      field.NH09.option.About_once_a_week: About once a week
+      field.NH09.option.1_to_3_times_per_month: 1 to 3 times per month
+      field.NH09.option.Rarely: Rarely
+      field.NH09.option.Never: Never"
+      field.NH16.label.Do_you_have_any_food: Do you have any food intolerances or allergies?
+      field.NH17.label.Which_foods_are_you_intolerant: Which foods are you intolerant or allergic to? (Multiple answers possible)
+      field.NH17.option.Milk_lactose: Milk (lactose)
+      field.NH17.option.Peanuts: Peanuts
+      field.NH17.option.Walnuts: Walnuts
+      field.NH17.option.Hazelnuts: Hazelnuts
+      field.NH17.option.Other_nuts: Other nuts
+      field.NH17.option.Shellfish: Shellfish
+      field.NH17.option.Soy: Soy
+      field.NH17.option.Gluten_containing_cereals: Gluten-containing cereals
+      field.NH17.option.Eggs: Eggs
+      field.NH17.option.Fish: Fish
+      field.NH17.option.Other_specify: "Other, specify:"
+      field.NH18.label.Other_allergy_specify: "Other allergy, specify:"
+      field.NH19.label.Has_this_milk_lactose: Has this milk (lactose) intolerance or allergy been confirmed by a doctor?
+      field.NH19.option.Yes: Yes
+      field.NH19.option.No: No
+      field.NH19.option.Don_t_know: Don't know
+      field.NH20.label.Has_this_peanut_intolerance_or: Has this peanut intolerance or allergy been confirmed by a doctor?
+      field.NH20.option.Yes: Yes
+      field.NH20.option.No: No
+      field.NH20.option.Don_t_know: Don't know
+      field.NH21.label.Has_this_nut_intolerance_or: Has this nut intolerance or allergy been confirmed by a doctor?
+      field.NH21.option.Yes: Yes
+      field.NH21.option.No: No
+      field.NH21.option.Don_t_know: Don't know
+      field.NH22.label.Has_this_shellfish_intolerance: Has this shellfish intolerance or allergy been confirmed by a doctor?
+      field.NH22.option.Yes: Yes
+      field.NH22.option.No: No
+      field.NH22.option.Don_t_know: Don't know
+      field.NH23.label.Has_this_soy_intolerance_or: Has this soy intolerance or allergy been confirmed by a doctor?
+      field.NH23.option.Yes: Yes
+      field.NH23.option.No: No
+      field.NH23.option.Don_t_know: Don't know
+      field.NH24.label.Has_this_gluten_intolerance_or: Has this gluten intolerance or allergy been confirmed by a doctor?
+      field.NH24.option.Yes: Yes
+      field.NH24.option.No: No
+      field.NH24.option.Don_t_know: Don't know
+      field.NH25.label.Has_this_egg_intolerance_or: Has this egg intolerance or allergy been confirmed by a doctor?
+      field.NH25.option.Yes: Yes
+      field.NH25.option.No: No
+      field.NH25.option.Don_t_know: Don't know
+      field.NH26.label.Has_this_fish_intolerance_or: Has this fish intolerance or allergy been confirmed by a doctor?
+      field.NH26.option.Yes: Yes
+      field.NH26.option.No: No
+      field.NH26.option.Don_t_know: Don't know
+      field.NH27.label.Has_another_intolerance_or: Has another intolerance or allergy been confirmed by a doctor?
+      section.Sleep_Quality: Sleep Quality
+      field.CD01.label.This_questionnaire_assesses_the: This questionnaire assesses the quality of your sleep
+      field.CD02.label.Do_you_have_trouble_falling: Do you have trouble falling asleep?
+      field.CD02.option.Never: Never
+      field.CD02.option.Rarely: Rarely
+      field.CD02.option.Occasionally: Occasionally
+      field.CD02.option.Most_of_the_time: Most of the time
+      field.CD02.option.Always: Always
+      field.CD03.label.Do_you_have_trouble_staying: Do you have trouble staying asleep?
+      field.CD03.option.Never: Never
+      field.CD03.option.Rarely: Rarely
+      field.CD03.option.Occasionally: Occasionally
+      field.CD03.option.Most_of_the_time: Most of the time
+      field.CD03.option.Always: Always
+      field.CD04.label.Do_you_take_medication_to_help: Do you take medication to help you sleep?
+      field.CD04.option.Never: Never
+      field.CD04.option.Rarely: Rarely
+      field.CD04.option.Occasionally: Occasionally
+      field.CD04.option.Most_of_the_time: Most of the time
+      field.CD04.option.Always: Always
+      field.CD05.label.Do_you_drink_alcohol_to_help: Do you drink alcohol to help you sleep?
+      field.CD05.option.Never: Never
+      field.CD05.option.Rarely: Rarely
+      field.CD05.option.Occasionally: Occasionally
+      field.CD05.option.Most_of_the_time: Most of the time
+      field.CD05.option.Always: Always
+      field.CD06.label.Is_there_a_health_problem_that: Is there a health problem that disrupts your sleep?
+      field.CD06.option.Never: Never
+      field.CD06.option.Rarely: Rarely
+      field.CD06.option.Occasionally: Occasionally
+      field.CD06.option.Most_of_the_time: Most of the time
+      field.CD06.option.Always: Always
+      field.CD07.label.Have_you_lost_all_interest_in: Have you lost all interest in your activities and hobbies?
+      field.CD07.option.Never: Never
+      field.CD07.option.Rarely: Rarely
+      field.CD07.option.Occasionally: Occasionally
+      field.CD07.option.Most_of_the_time: Most of the time
+      field.CD07.option.Always: Always
+      field.CD08.label.Do_you_feel_sad_irritable_or: Do you feel sad, irritable, or hopeless?
+      field.CD08.option.Never: Never
+      field.CD08.option.Rarely: Rarely
+      field.CD08.option.Occasionally: Occasionally
+      field.CD08.option.Most_of_the_time: Most of the time
+      field.CD08.option.Always: Always
+      field.CD09.label.Do_you_feel_nervous_or_anxious: Do you feel nervous or anxious?
+      field.CD09.option.Never: Never
+      field.CD09.option.Rarely: Rarely
+      field.CD09.option.Occasionally: Occasionally
+      field.CD09.option.Most_of_the_time: Most of the time
+      field.CD09.option.Always: Always
+      field.CD10.label.Do_you_think_there_is_something: Do you think there is something wrong with your body?
+      field.CD10.option.Never: Never
+      field.CD10.option.Rarely: Rarely
+      field.CD10.option.Occasionally: Occasionally
+      field.CD10.option.Most_of_the_time: Most of the time
+      field.CD10.option.Always: Always
+      field.CD11.label.Is_your_work_schedule_variable: Is your work schedule variable? Does your sleep pattern change?
+      field.CD11.option.Never: Never
+      field.CD11.option.Rarely: Rarely
+      field.CD11.option.Occasionally: Occasionally
+      field.CD11.option.Most_of_the_time: Most of the time
+      field.CD11.option.Always: Always
+      field.CD12.label.Are_your_legs_restless_and_or: Are your legs restless and/or uncomfortable before sleeping?
+      field.CD12.option.Never: Never
+      field.CD12.option.Rarely: Rarely
+      field.CD12.option.Occasionally: Occasionally
+      field.CD12.option.Most_of_the_time: Most of the time
+      field.CD12.option.Always: Always
+      field.CD13.label.Have_you_been_told_that_you_are: Have you been told that you are restless or kick during your sleep?
+      field.CD13.option.Never: Never
+      field.CD13.option.Rarely: Rarely
+      field.CD13.option.Occasionally: Occasionally
+      field.CD13.option.Most_of_the_time: Most of the time
+      field.CD13.option.Always: Always
+      field.CD14.label.Do_you_have_unusual_behaviours: Do you have unusual behaviours or movements during your sleep?
+      field.CD14.option.Never: Never
+      field.CD14.option.Rarely: Rarely
+      field.CD14.option.Occasionally: Occasionally
+      field.CD14.option.Most_of_the_time: Most of the time
+      field.CD14.option.Always: Always
+      field.CD15.label.Do_you_snore: Do you snore?
+      field.CD15.option.Never: Never
+      field.CD15.option.Rarely: Rarely
+      field.CD15.option.Occasionally: Occasionally
+      field.CD15.option.Most_of_the_time: Most of the time
+      field.CD15.option.Always: Always
+      field.CD16.label.Have_you_been_told_that_you: Have you been told that you stop breathing, snore, or choke in your sleep?
+      field.CD16.option.Never: Never
+      field.CD16.option.Rarely: Rarely
+      field.CD16.option.Occasionally: Occasionally
+      field.CD16.option.Most_of_the_time: Most of the time
+      field.CD16.option.Always: Always
+      field.CD17.label.Do_you_have_trouble_staying: Do you have trouble staying awake during the day?
+      field.CD17.option.Never: Never
+      field.CD17.option.Rarely: Rarely
+      field.CD17.option.Occasionally: Occasionally
+      field.CD17.option.Most_of_the_time: Most of the time
+      field.CD17.option.Always: Always
+      field.CD18.label.Total_score: "Total score:"
+      group.Note_to_physician._Help_with: Note to physician. Help with interpreting results
+      field.CD20.label.SO1_15_Insomnia: "SO1-15: Insomnia"
+      field.CD21.label.With_a_score_of_3_4_or_5_on_any: With a score of 3, 4, or 5 on any question, the patient likely suffers from insomnia. If they score 3, 4, or 5 on two or more items and have significant daytime impairment, the insomnia requires further evaluation and management
+      field.CD22.label.SO6_9_Mental_health_disorders: "SO6-9: Mental health disorders"
+      field.CD23.label.Scores_of_4_or_5_on_questions_6: Scores of 4 or 5 on questions 6 to 9 require further screening for psychiatric disorders. Question 8 refers to somatisation and may reflect an underlying somatoform disorder requiring specific treatment.
+      field.CD24.label.SO10_Circadian_rhythm_disorders: "SO10: Circadian rhythm disorders"
+      field.CD25.label.A_score_of_4_or_5_on_question: A score of 4 or 5 on question 10 may indicate a circadian rhythm disorder. Further questioning about shift work or a preference for a delayed sleep phase.
+      field.CD26.label.SO11_12_Restless_legs_syndrome: "SO11-12: Restless legs syndrome"
+      field.CD27.label.A_score_of_4_or_5_on_question: A score of 4 or 5 on question 11 or 12 is significant and likely contributes to insomnia symptoms or non-restorative sleep. Question 11 refers to restless legs syndrome and question 12 refers to periodic limb movement disorder.
+      field.CD28.label.SO13_Parasomnias: "SO13: Parasomnias"
+      field.CD29.label.A_score_of_2_to_5_on_question: A score of 2 to 5 on question 14 should raise concerns, especially if the event or movement is violent or potentially injurious to the patient or their bed partner.
+      field.CD30.label.SO14_16_Sleep_apnoea: "SO14-16: Sleep apnoea"
+      field.CD31.label.A_score_of_4_or_5_on_question: A score of 4 or 5 on question 14 or 15 alone requires further clinical evaluation for sleep apnoea. A score above 3 on questions 14 and 15 or 14 and 16 is also suspicious for sleep apnoea and further evaluation should be performed.
+      section.Dependencies: Dependencies
+      group.Tobacco: Tobacco
+      field.DEP01.label.Describe_your_smoking_behaviour: "Describe your smoking behaviour:"
+      field.DEP01.option.I_have_never_smoked: I have never smoked
+      field.DEP01.option.I_used_to_smoke_but_I_have_quit: I used to smoke but I have quit
+      field.DEP01.option.I_smoke: I smoke
+      field.DEP11.label.How_many_years_ago_did_you_quit: How many years ago did you quit smoking?
+      field.DEP02.label.Amount_consumed: "Amount consumed:"
+      field.DEP03.label.Duration_of_consumption_in_years: "Duration of consumption (in years):"
+      group.Alcohol: Alcohol
+      field.DEP04.label.Describe_your_alcohol: "Describe your alcohol consumption:"
+      field.DEP04.option.I_drink_alcohol: I drink alcohol
+      field.DEP04.option.I_have_never_consumed_alcohol: I have never consumed alcohol
+      field.DEP04.option.I_used_to_drink_alcohol_but_I: I used to drink alcohol but I have quit
+      field.DEP12.label.How_many_years_ago_did_you_stop: How many years ago did you stop drinking alcohol?
+      field.DEP05.label.Amount_consumed: "Amount consumed:"
+      field.DEP06.label.Duration_of_consumption_in_years: "Duration of consumption (in years):"
+      section.General_Practitioner: General Practitioner
+      field.GP01.label.Contact_with_a_general: Contact with a general practitioner
+      field.GP02.label.Here_are_some_questions_about: Here are some questions about your use of healthcare services. Please note, this concerns your own use of healthcare services only.
+      field.GP03.label.Do_you_have_a_regular_general: Do you have a regular general practitioner or a regular group of general practitioners (this may include a medical centre)?
+      field.GP03.option.Yes: Yes
+      field.GP03.option.No: No
+      field.GP03.option.Don_t_know: Don't know
+      field.GP04.label.The_following_questions_concern: The following questions concern your consultations with a general practitioner. This includes office visits, home visits, and telephone consultations.
+      field.GP05.label.When_did_you_last_see_a_general: When did you last see a general practitioner?
+      field.GP05.option.Less_than_6_months_ago: Less than 6 months ago
+      field.GP05.option.More_than_6_months_ago: More than 6 months ago
+      field.GP05.option.Never: Never
+      field.GP05.option.Don_t_know: Don't know
+  - language: nl
+    translations:
+      section.Summary: Samenvatting
+      group.Patient_Data: Patiëntgegevens
+      field.DP1.label.Name: Naam
+      field.DP2.label.Gender: Geslacht
+      field.DP3.label.Date_of_Birth: Geboortedatum
+      field.GI01.label.Weight_kg: Gewicht, kg
+      field.GI02.label.Height_cm: Lengte, cm
+      field.GI03.label.BMI_kg_m2: BMI, kg/m2
+      field.GI04.label.Waist_circumference_cm: Tailleomtrek, cm
+      field.GI08.label.Blood_type: Bloedgroep
+      field.GI05.label.SBP_mmHg: Syst. BD, mmHg
+      field.GI06.label.DBP_mmHg: Diast. BD, mmHg
+      field.GI07.label.HR_bpm: Hartslag, bpm
+      field.GI10.label.HDL_mmol_l: HDL, mmol/l
+      field.GI11.label.CV_Score: CV Score
+      group.Medical_Summary: Medisch Overzicht
+      field.RM1.label.Chronic_treatments: Chronische behandelingen
+      field.RM2.label.Allergies: Allergieën
+      field.RM3.label.Medical_history: Medische voorgeschiedenis
+      field.RM4.label.Surgical_history: Chirurgische voorgeschiedenis
+      field.RM5.label.Family_history: Familiegeschiedenis
+      group.Recommendations: Aanbevelingen
+      field.RE01.label.General_health_status: Algemene gezondheidstoestand
+      field.RE02.label.Social_and_environmental_context: Sociale en omgevingscontext
+      field.RE03.label.Mental_health: Mentale gezondheid
+      field.RE03B.label.Sleep_quality: Slaapkwaliteit
+      field.RE04.label.Nutrition_and_physical_activity: Voeding en lichaamsbeweging
+      field.RE05.label.Alcohol_consumption_and: Alcoholgebruik en verslavingen
+      field.RE06.label.Quality_and_life_expectancy: Levenskwaliteit en levensverwachting
+      field.RE07.label.Health_journey: Gezondheidspad
+      field.RE08.label.Blood_test_results: Resultaten van de bloedafname
+      field.RE09.label.Conclusion._Key_recommendations: Conclusie. Belangrijkste aanbevelingen
+      section.General_Information: Algemene Informatie
+      field.GI01.label.Weight_kg_2: Gewicht, kg
+      field.GI02.label.Height_cm_2: Lengte, cm
+      field.GI03.label.BMI_kg_m2_2: BMI, kg/m2
+      field.GI04.label.Waist_circumference_cm_2: Tailleomtrek, cm
+      field.GI05.label.Blood_pressure_systolic_mmHg: Bloeddruk (systolisch), mmHg
+      field.GI06.label.Blood_pressure_diastolic_mmHg: Bloeddruk (diastolisch), mmHg
+      field.GI07.label.Heart_rate_bpm: Hartslag, bpm
+      field.GI08.label.Blood_type_2: Bloedgroep
+      field.GI09.label.How_many_children_do_you_have: Hoeveel kinderen heeft u
+      field.MS1.label.STD_screening: SOA-screening
+      field.CP1.label.Patient_comment: Patiëntopmerking
+      section.Caregiver: Mantelzorger
+      field.IC01.label.Do_you_at_least_once_a_week: Verleent u, minstens één keer per week, buiten uw beroep, hulp of zorg aan één of meerdere personen met leeftijdsgerelateerde problemen, een chronische ziekte, een langdurige aandoening of een handicap?
+      field.IC01.option.Yes: Ja
+      field.IC01.option.No: Nee
+      field.IC02.label.Outside_your_profession_to_whom: Buiten uw beroep, aan wie verleent u de meeste hulp of zorg? (slechts één antwoord mogelijk)
+      field.IC02.option.One_or_more_household_member_s: Eén of meer huishoudlid/leden
+      field.IC02.option.One_or_more_family_member_s_but: Eén of meer familielid/leden maar geen huishoudlid/leden
+      field.IC02.option.One_or_more_persons_not: Eén of meer personen, geen huishoud- of familielid/leden
+      field.IC03.label.In_total_how_many_hours_per: Hoeveel uur per week besteedt u in totaal gewoonlijk aan het verlenen van hulp of zorg?
+      field.IC03.option.Less_than_10_hours_per_week: Minder dan 10 uur per week
+      field.IC03.option.At_least_10_hours_but_less_than: Minstens 10 uur, maar minder dan 20 uur per week
+      field.IC03.option.20_hours_per_week_or_more: 20 uur per week of meer
+      section.Social_Life: Sociaal Leven
+      field.SO01.label.How_would_you_overall_describe: Hoe zou u over het algemeen uw sociale contacten omschrijven (familie, vrienden, omgeving)?
+      field.SO01.option.Very_satisfying: Zeer bevredigend
+      field.SO01.option.Rather_satisfying: Eerder bevredigend
+      field.SO01.option.Rather_unsatisfying: Eerder onbevredigend
+      field.SO01.option.Really_unsatisfying: Echt onbevredigend
+      field.SO03.label.How_many_people_are_close: Hoeveel personen staan dicht genoeg bij u zodat u op hen kunt rekenen bij belangrijke moeilijkheden?
+      field.SO03.option.None: Geen
+      field.SO03.option.1_or_2: 1 of 2
+      field.SO03.option.3_to_5: 3 tot 5
+      field.SO03.option.6_or_more: 6 of meer
+      section.Environmental_Factors: Omgevingsfactoren
+      field.HE01.label.I_will_now_ask_you_2_sets_of: Ik ga u nu 2 reeksen vragen stellen over omgevingsfactoren. De eerste reeks gaat over omgevingsfactoren in uw wijk, terwijl de tweede reeks gaat over factoren die u thuis kunnen beïnvloeden.
+      group.Series_1_Neighbourhood: "Reeks 1: Wijk"
+      field.HE03.label.In_your_neighbourhood_to_what: In uw wijk of buurt, in welke mate vormen de volgende omstandigheden een probleem?
+      field.HE04.label.Is_traffic_speed_or_volume_a: Is de verkeerssnelheid of het verkeersvolume een probleem?
+      field.HE04.option.Not_a_problem_at_all: Helemaal geen probleem
+      field.HE04.option.Minor_problem: Klein probleem
+      field.HE04.option.Fairly_big_problem: Vrij groot probleem
+      field.HE04.option.Very_big_problem: Zeer groot probleem
+      field.HE04.option.Don_t_know: Weet niet
+      field.HE04.option.No_answer: Geen antwoord
+      field.HE07.label.Does_lack_of_access_to_parks_or: Vormt het gebrek aan toegang tot parken of andere openbare groene of recreatieve ruimtes een probleem?
+      field.HE07.option.Not_a_problem_at_all: Helemaal geen probleem
+      field.HE07.option.Minor_problem: Klein probleem
+      field.HE07.option.Fairly_big_problem: Vrij groot probleem
+      field.HE07.option.Very_big_problem: Zeer groot probleem
+      field.HE07.option.Don_t_know: Weet niet
+      field.HE07.option.No_answer: Geen antwoord
+      group.Series_2_Home: "Reeks 2: Thuis"
+      field.HE09.label.Thinking_about_the_last_12: Als u denkt aan de afgelopen 12 maanden, op welke manier wordt u thuis gehinderd, getroffen of gestoord door de volgende omstandigheden?
+      field.HE10.label.Does_air_pollution_pose_a: Is luchtvervuiling een probleem?
+      field.HE10.option.Not_at_all: Helemaal niet
+      field.HE10.option.Slightly: Licht
+      field.HE10.option.Moderately: Matig
+      field.HE10.option.A_lot: Veel
+      field.HE10.option.Extremely: Extreem
+      field.HE10.option.Don_t_know: Weet niet
+      field.HE10.option.No_answer: Geen antwoord
+      field.HE13.label.Is_traffic_noise_a_problem_road: Is verkeerslawaai een probleem? (weg, trein, tram, metro, vliegtuig)
+      field.HE13.option.Not_at_all: Helemaal niet
+      field.HE13.option.Slightly: Licht
+      field.HE13.option.Moderately: Matig
+      field.HE13.option.A_lot: Veel
+      field.HE13.option.Extremely: Extreem
+      field.HE13.option.Don_t_know: Weet niet
+      field.HE13.option.No_answer: Geen antwoord
+      field.HE16.label.Does_noise_from_nearby: Vormt lawaai van nabijgelegen bedrijven (fabriek, werkplaats) een probleem?
+      field.HE16.option.Not_at_all: Helemaal niet
+      field.HE16.option.Slightly: Licht
+      field.HE16.option.Moderately: Matig
+      field.HE16.option.A_lot: Veel
+      field.HE16.option.Extremely: Extreem
+      field.HE16.option.Don_t_know: Weet niet
+      field.HE16.option.No_answer: Geen antwoord
+      section.Work_Absence: Werkverzuim
+      field.AW01.label.In_the_past_12_months_were_you: Bent u in de afgelopen 12 maanden afwezig geweest op uw werk om gezondheidsredenen? (alle ziektes, verwondingen of gezondheidsproblemen die tot afwezigheid hebben geleid)
+      field.AW01.option.Yes: Ja
+      field.AW01.option.No: Nee
+      field.AW02.label.In_the_past_12_months_how_many: Hoeveel dagen in totaal was u in de afgelopen 12 maanden afwezig op uw werk om gezondheidsredenen? Als u het exacte aantal dagen niet weet, geef dan een schatting.
+      field.AW03.label.What_is_the_main_reason_for: Wat is de belangrijkste reden voor deze afwezigheid?
+      field.AW03.option.Physical_health_problem: Fysiek gezondheidsprobleem
+      field.AW03.option.Fatigue_stress_or_burnout: Vermoeidheid, stress of uitputting
+      field.AW03.option.Accident_or_injury: Ongeval of verwonding
+      field.AW03.option.Other_reason: Andere reden
+      field.AW03.option.I_prefer_not_to_answer: Ik geef er de voorkeur aan niet te antwoorden
+      section.Medical_History: Medische Voorgeschiedenis
+      group.Cardiovascular_history: Cardiovasculaire voorgeschiedenis
+      field.CV00.label.The_following_questions_concern: De volgende vragen gaan over uw cardiovasculaire gezondheid (hart en bloedvaten).
+      field.CV01.label.Has_a_doctor_ever_diagnosed_you: Heeft een arts bij u ooit een of meer van de volgende ziekten vastgesteld? (Meerdere antwoorden mogelijk)
+      field.CV01.option.High_blood_pressure: Hoge bloeddruk
+      field.CV01.option.Coronary_artery_disease_angina: Coronaire hartziekte / angina pectoris
+      field.CV01.option.Myocardial_infarction: Hartinfarct
+      field.CV01.option.Heart_rhythm_disorder_e.g.: Hartritmestoornis (bv. atriumfibrillatie)
+      field.CV01.option.Heart_failure: Hartfalen
+      field.CV01.option.Stroke_CVA_or_TIA: Cerebrovasculair accident (CVA) of TIA
+      field.CV01.option.Peripheral_artery_disease: Perifeer arterieel vaatlijden
+      field.CV01.option.Other_cardiovascular_disease: Andere cardiovasculaire ziekte
+      field.CV01.option.None: Geen
+      field.CV01.option.I_don_t_know: Ik weet het niet
+      field.CV02.label.Are_you_currently_taking: Neemt u momenteel medicatie voor het hart of de bloeddruk?
+      field.CV02.option.Yes: Ja
+      field.CV02.option.No: Nee
+      field.CV02.option.I_don_t_know: Ik weet het niet
+      field.CV03.label.In_recent_months_have_you: Heeft u de afgelopen maanden regelmatig een of meer van de volgende symptomen ervaren? (Meerdere antwoorden mogelijk)
+      field.CV03.option.Unusual_shortness_of_breath_on: Ongewone kortademigheid bij inspanning
+      field.CV03.option.Chest_pain_or_tightness: Pijn of druk op de borst
+      field.CV03.option.Palpitations_or_irregular: Hartkloppingen of onregelmatige hartslag
+      field.CV03.option.Dizziness_faintness_or_loss_of: Duizeligheid, onwelwording of bewustzijnsverlies
+      field.CV03.option.Swelling_of_ankles_or_legs: Zwelling van de enkels of benen
+      field.CV03.option.None_of_these_symptoms: Geen van deze symptomen
+      field.CV04.label.Are_you_currently_being: Wordt u momenteel door een arts gevolgd voor uw hart of bloeddruk?
+      field.CV04.option.Yes: Ja
+      field.CV04.option.No: Nee
+      field.CV04.option.I_don_t_know: Ik weet het niet
+      group.Metabolic_Endocrine_history: Metabole / endocriene voorgeschiedenis
+      field.EN00.label.The_following_questions_concern: De volgende vragen gaan over uw metabolisme (suiker, cholesterol, hormonen).
+      field.EN01.label.Has_a_doctor_ever_diagnosed_you: Heeft een arts bij u ooit een of meer van de volgende ziekten vastgesteld? (Meerdere antwoorden mogelijk)
+      field.EN01.option.Type_2_diabetes: Diabetes type 2
+      field.EN01.option.Type_1_diabetes: Diabetes type 1
+      field.EN01.option.Prediabetes_glucose_intolerance: Prediabetes / glucoseintolerantie
+      field.EN01.option.High_cholesterol_dyslipidaemia: Hoog cholesterol (dyslipidemie)
+      field.EN01.option.Thyroid_disease_hypo_or: Schildklierziekte (hypo- of hyperthyreoïdie)
+      field.EN01.option.Metabolic_syndrome: Metabool syndroom
+      field.EN01.option.Other_metabolic_or_endocrine: Andere metabole of endocriene ziekte
+      field.EN01.option.None: Geen
+      field.EN01.option.I_don_t_know: Ik weet het niet
+      field.EN02.label.Are_you_currently_being: Wordt u momenteel door een arts gevolgd voor een probleem gerelateerd aan het metabolisme (suiker, cholesterol, schildklier, hormonen)?
+      field.EN02.option.Yes: Ja
+      field.EN02.option.No: Nee
+      field.EN02.option.I_don_t_know: Ik weet het niet
+      group.Respiratory_history: Respiratoire voorgeschiedenis
+      field.RS00.label.The_following_questions_concern: De volgende vragen gaan over uw ademhalingsgezondheid.
+      field.RS01.label.Have_you_ever_been_diagnosed_by: Heeft een arts bij u ooit een luchtwegaandoening vastgesteld?
+      field.RS01.option.Yes: Ja
+      field.RS01.option.No: Nee
+      field.RS01.option.I_don_t_know_I_m_not_sure: Ik weet het niet / ik ben niet zeker
+      field.RS02.label.What_respiratory_diagnosis: Welke respiratoire diagnose(s) werd(en) door een arts bij u gesteld? (Meerdere antwoorden mogelijk)
+      field.RS02.option.Asthma_current: Astma (huidig)
+      field.RS02.option.Childhood_past_asthma: Astma in de kindertijd / vroeger
+      field.RS02.option.Chronic_obstructive_pulmonary: "Chronisch obstructieve longziekte (COPD: chronische bronchitis en/of emfyseem)"
+      field.RS02.option.Recurrent_bronchitis: Herhaalde bronchitis
+      field.RS02.option.Pulmonary_fibrosis: Longfibrose
+      field.RS02.option.Sarcoidosis: Sarcoïdose
+      field.RS02.option.Allergic_alveolitis: Allergische alveolitis
+      field.RS02.option.Cystic_fibrosis: Mucoviscidose
+      field.RS02.option.Other_diagnosed_respiratory: Andere gediagnosticeerde luchtwegaandoening (specificeer)
+      field.RS02.option.I_don_t_know_the_exact_diagnosis: Ik ken de exacte diagnose niet
+      field.RS03.label.Are_you_currently_being_treated: Wordt u momenteel behandeld voor een ademhalingsprobleem? (Meerdere antwoorden mogelijk)
+      field.RS03.option.Inhaler_spray_e.g.: Inhalator / spray (bv. bronchodilatator, inhalatiecorticosteroïd)
+      field.RS03.option.Night_time_ventilation_CPAP: Nachtelijke beademing (CPAP)
+      field.RS03.option.Home_oxygen_therapy: Thuiszuurstof
+      field.RS03.option.Other_respiratory_treatment: Andere respiratoire behandeling
+      field.RS03.option.No_respiratory_treatment: Geen respiratoire behandeling
+      field.RS04.label.Do_you_currently_have_one_or: Heeft u momenteel een of meer van de volgende symptomen? (Meerdere antwoorden mogelijk)
+      field.RS04.option.Shortness_of_breath_on_exertion: Kortademigheid bij inspanning of in rust
+      field.RS04.option.Wheezing: Piepende ademhaling
+      field.RS04.option.Chronic_cough: Chronische hoest
+      field.RS04.option.Persistent_fatigue_possibly: Aanhoudende vermoeidheid mogelijk gerelateerd aan de ademhaling
+      field.RS04.option.Significant_snoring: Ernstig snurken
+      field.RS04.option.No_respiratory_symptoms: Geen respiratoire symptomen
+      group.Musculoskeletal_history: Musculoskeletale voorgeschiedenis
+      field.MQ00.label.The_following_questions_concern: De volgende vragen gaan over uw musculoskeletaal stelsel (rug, gewrichten, spieren, pezen).
+      field.MQ01.label.Has_a_doctor_ever_diagnosed_you: Heeft een arts bij u ooit een of meer van de volgende aandoeningen vastgesteld? (Meerdere antwoorden mogelijk)
+      field.MQ01.option.Chronic_low_back_pain_herniated: Chronische lage rugpijn / hernia / ischias
+      field.MQ01.option.Chronic_neck_pain: Chronische nekpijn
+      field.MQ01.option.Osteoarthritis_hip_knee_spine: Artrose (heup, knie, wervelkolom, andere)
+      field.MQ01.option.Chronic_tendinitis_shoulder: Chronische tendinitis (schouder, elleboog, pols, andere)
+      field.MQ01.option.Carpal_tunnel_syndrome: Carpaal tunnel syndroom
+      field.MQ01.option.Work_related_musculoskeletal: Werkgerelateerde musculoskeletale aandoening (erkende RSI)
+      field.MQ01.option.Other_musculoskeletal_condition: Andere musculoskeletale aandoening
+      field.MQ01.option.None: Geen
+      field.MQ01.option.I_don_t_know: Ik weet het niet
+      field.MQ02.label.Are_you_currently_being_treated: Wordt u momenteel gevolgd voor een musculoskeletaal probleem? (arts, kinesitherapeut, reumatoloog, osteopaat, enz.)
+      field.MQ02.option.Yes: Ja
+      field.MQ02.option.No: Nee
+      field.MQ02.option.I_don_t_know: Ik weet het niet
+      field.MQ03.label.In_recent_months_have_you: Heeft u de afgelopen maanden regelmatig een of meer van de volgende symptomen ervaren? (Meerdere antwoorden mogelijk)
+      field.MQ03.option.Back_or_neck_pain: Rug- of nekpijn
+      field.MQ03.option.Shoulder_arm_or_wrist_pain: Pijn aan schouders, armen of polsen
+      field.MQ03.option.Hip_knee_or_ankle_pain: Pijn aan heupen, knieën of enkels
+      field.MQ03.option.Prolonged_joint_stiffness: Langdurige gewrichtsstijfheid
+      field.MQ03.option.Decreased_mobility_or_strength: Verminderde mobiliteit of kracht
+      field.MQ03.option.None_of_these_symptoms: Geen van deze symptomen
+      field.MQ04.label.Do_these_pains_or_limitations: Hebben deze pijn of beperkingen een impact op uw dagelijks leven of uw werk?
+      field.MQ04.option.Not_at_all: Helemaal niet
+      field.MQ04.option.A_little: Een beetje
+      field.MQ04.option.A_lot: Veel
+      field.MQ04.option.Not_applicable_no_pain: Niet van toepassing (geen pijn)
+      group.Neurological_history: Neurologische voorgeschiedenis
+      field.NE00.label.The_following_questions_concern: De volgende vragen gaan over uw neurologisch stelsel (hersenen, zenuwen, evenwicht).
+      field.NE01.label.Has_a_doctor_ever_diagnosed_you: Heeft een arts bij u ooit een of meer van de volgende ziekten vastgesteld? (Meerdere antwoorden mogelijk)
+      field.NE01.option.Chronic_migraine: Chronische migraine
+      field.NE01.option.Epilepsy: Epilepsie
+      field.NE01.option.Multiple_sclerosis: Multiple sclerose
+      field.NE01.option.Parkinson_s_disease: Ziekte van Parkinson
+      field.NE01.option.Peripheral_neuropathy_tingling: Perifere neuropathie (tintelingen, gevoelsverlies…)
+      field.NE01.option.Neurological_disorder_following: Neurologische aandoening na een CVA
+      field.NE01.option.Other_neurological_disease: Andere neurologische ziekte
+      field.NE01.option.None: Geen
+      field.NE01.option.I_don_t_know: Ik weet het niet
+      field.NE02.label.Are_you_currently_being: Wordt u momenteel door een arts gevolgd voor een neurologisch probleem?
+      field.NE02.option.Yes: Ja
+      field.NE02.option.No: Nee
+      field.NE02.option.I_don_t_know: Ik weet het niet
+      field.NE03.label.In_recent_months_have_you: Heeft u de afgelopen maanden regelmatig een of meer van de volgende symptomen ervaren die NIET verklaard worden door een bekende neurologische diagnose? (Meerdere antwoorden mogelijk)
+      field.NE03.option.Frequent_or_unusual_headaches: Frequente of ongewone hoofdpijn
+      field.NE03.option.Dizziness_or_balance_problems: Duizeligheid of evenwichtsstoornissen
+      field.NE03.option.Numbness_tingling_or_loss_of: Gevoelloosheid, tintelingen of gevoelsverlies
+      field.NE03.option.Unexplained_muscle_weakness: Onverklaarde spierzwakte
+      field.NE03.option.Concentration_or_memory_problems: Concentratie- of geheugenstoornissen
+      field.NE03.option.Unusual_tremors: Ongewone tremoren
+      field.NE03.option.None_of_these_symptoms: Geen van deze symptomen
+      field.NE04.label.Do_these_symptoms_impact_your: Hebben deze symptomen een impact op uw dagelijks leven of uw werk?
+      field.NE04.option.Not_at_all: Helemaal niet
+      field.NE04.option.A_little: Een beetje
+      field.NE04.option.A_lot: Veel
+      field.NE04.option.Not_applicable_no_symptoms: Niet van toepassing (geen symptomen)
+      group.Digestive_hepatic_history: Spijsverterings- / levervoorgeschiedenis
+      field.DG00.label.The_following_questions_concern: De volgende vragen gaan over uw spijsverteringsstelsel en uw lever.
+      field.DG01.label.Has_a_doctor_ever_diagnosed_you: Heeft een arts bij u ooit een of meer van de volgende ziekten vastgesteld? (Meerdere antwoorden mogelijk)
+      field.DG01.option.Gastroesophageal_reflux_disease: Gastro-oesofageale reflux (GERD)
+      field.DG01.option.Stomach_or_duodenal_ulcer: Maag- of duodenumulcus
+      field.DG01.option.Irritable_bowel_syndrome_IBS: Prikkelbare darmsyndroom (PDS)
+      field.DG01.option.Inflammatory_bowel_disease: Chronische inflammatoire darmziekte (Crohn, colitis ulcerosa)
+      field.DG01.option.Liver_disease_fatty_liver: Leverziekte (leververvetting, chronische hepatitis, cirrose…)
+      field.DG01.option.Digestive_polyps_or_history_of: Darmpoliepen of voorgeschiedenis van spijsverteringskanker
+      field.DG01.option.Other_digestive_or_liver_disease: Andere spijsverterings- of leverziekte
+      field.DG01.option.None: Geen
+      field.DG01.option.I_don_t_know: Ik weet het niet
+      field.DG02.label.Are_you_currently_being: Wordt u momenteel door een arts gevolgd voor een spijsverterings- of leverprobleem?
+      field.DG02.option.Yes: Ja
+      field.DG02.option.No: Nee
+      field.DG02.option.I_don_t_know: Ik weet het niet
+      field.DG03.label.In_recent_months_have_you: Heeft u de afgelopen maanden regelmatig een of meer van de volgende symptomen ervaren die NIET verklaard worden door een bekende spijsverteringsdiagnose? (Meerdere antwoorden mogelijk)
+      field.DG03.option.Heartburn_or_acid_reflux: Brandend maagzuur of zure oprispingen
+      field.DG03.option.Recurrent_abdominal_pain: Terugkerende buikpijn
+      field.DG03.option.Significant_bloating_or: Ernstige opgeblazenheid of frequent spijsverteringsongemak
+      field.DG03.option.Bowel_irregularities_persistent: Stoelgangproblemen (aanhoudende diarree of constipatie)
+      field.DG03.option.Frequent_nausea: Frequente misselijkheid
+      field.DG03.option.Unusual_stools_colour_appearance: Ongewone ontlasting (kleur, aspect)
+      field.DG03.option.None_of_these_symptoms: Geen van deze symptomen
+      field.DG04.label.Do_these_digestive_issues: Hebben deze spijsverteringsproblemen een impact op uw dagelijks leven of uw werk?
+      field.DG04.option.Not_at_all: Helemaal niet
+      field.DG04.option.A_little: Een beetje
+      field.DG04.option.A_lot: Veel
+      field.DG04.option.Not_applicable_no_symptoms: Niet van toepassing (geen symptomen)
+      group.Urinary_history: Urologische voorgeschiedenis
+      field.UR00.label.The_following_questions_concern: De volgende vragen gaan over uw nieren en uw urinewegen.
+      field.UR01.label.Has_a_doctor_ever_diagnosed_you: Heeft een arts bij u ooit een nier- of urinewegaandoening vastgesteld? (Meerdere antwoorden mogelijk)
+      field.UR01.option.Chronic_kidney_disease: Chronisch nierfalen
+      field.UR01.option.Recurrent_kidney_stones: Terugkerende nierstenen (lithiasis)
+      field.UR01.option.Recurrent_urinary_tract: Terugkerende urineweginfecties
+      field.UR01.option.Chronic_kidney_or_urinary: Chronische nier- of urinewegziekte (andere)
+      field.UR01.option.None: Geen
+      field.UR01.option.I_don_t_know: Ik weet het niet
+      field.UR02.label.Are_you_currently_being: Wordt u momenteel door een arts gevolgd voor een nier- of urinewegprobleem?
+      field.UR02.option.Yes: Ja
+      field.UR02.option.No: Nee
+      field.UR02.option.I_don_t_know: Ik weet het niet
+      field.UR03.label.In_recent_months_have_you: Heeft u de afgelopen maanden regelmatig een of meer van de volgende symptomen gehad die NIET verklaard worden door een bekende urinaire of renale diagnose? (Meerdere antwoorden mogelijk)
+      field.UR03.option.Frequent_need_to_urinate: Frequente aandrang om te plassen
+      field.UR03.option.Night_time_urination_nocturia: Nachtelijk opstaan om te plassen (nycturie)
+      field.UR03.option.Pain_or_burning_during_urination: Pijn of branderig gevoel bij het plassen
+      field.UR03.option.Difficulty_completely_emptying: Moeite om de blaas volledig te ledigen
+      field.UR03.option.Unexplained_lower_back_pain: Onverklaarde lage rugpijn
+      field.UR03.option.None_of_these_symptoms: Geen van deze symptomen
+      field.UR04.label.Do_these_urinary_issues_impact: Hebben deze urinaire klachten een impact op uw slaap, uw dagelijks leven of uw werk?
+      field.UR04.option.Not_at_all: Helemaal niet
+      field.UR04.option.A_little: Een beetje
+      field.UR04.option.A_lot: Veel
+      field.UR04.option.Not_applicable_no_symptoms: Niet van toepassing (geen symptomen)
+      group.Personal_history_of_cancer: Persoonlijke voorgeschiedenis van kanker
+      field.CA00.label.The_following_questions_concern: De volgende vragen gaan over uw persoonlijke voorgeschiedenis van kanker.
+      field.CA01.label.Has_a_doctor_ever_diagnosed_you: Heeft een arts bij u ooit kanker vastgesteld, nu of in het verleden (ook als u genezen bent)?
+      field.CA01.option.Yes: Ja
+      field.CA01.option.No: Nee
+      field.CA01.option.I_don_t_know: Ik weet het niet
+      field.CA02.label.What_type_of_cancer_Multiple: Welk type kanker? (Meerdere antwoorden mogelijk)
+      field.CA02.option.Breast: Borst
+      field.CA02.option.Prostate: Prostaat
+      field.CA02.option.Lung: Long
+      field.CA02.option.Colorectal: Colorectaal
+      field.CA02.option.Skin: Huid
+      field.CA02.option.Gynaecological: Gynaecologisch
+      field.CA02.option.Other_specify: Andere (specificeer)
+      field.CA02_PRECISION.label.Specify_the_type_of_cancer: Specificeer het type kanker
+      group.Other_medical_history: Overige medische voorgeschiedenis
+      field.OT00.label.The_following_questions_concern: De volgende vragen gaan over eventuele andere medische voorgeschiedenis.
+      field.OT01.label.Apart_from_what_has_already: "Heeft u, buiten wat al in deze vragenlijst aan bod is gekomen, een ander chronisch gezondheidsprobleem of een belangrijke medische voorgeschiedenis die een impact heeft op uw dagelijks leven of uw werk? (Bijvoorbeeld: oogheelkundig, gynaecologisch, KNO, dermatologisch, anders)"
+      field.OT01.option.Yes: Ja
+      field.OT01.option.No: Nee
+      field.OT02.label.Can_you_specify_in_a_few_words: Kunt u dit in enkele woorden verduidelijken? (Vrij tekstveld – facultatief)
+      field.OT03.label.Do_these_issues_impact_your: Hebben deze klachten een impact op uw dagelijks leven of uw werk?
+      field.OT03.option.Not_at_all: Helemaal niet
+      field.OT03.option.A_little: Een beetje
+      field.OT03.option.A_lot: Veel
+      field.OT03.option.Not_applicable_no_symptoms: Niet van toepassing (geen symptomen)
+      field.OT04.label.Are_you_generally_up_to_date: Bent u over het algemeen in orde met uw aanbevolen vaccinaties voor volwassenen (volgens uw arts)?
+      field.OT04.option.Yes: Ja
+      field.OT04.option.No: Nee
+      field.OT04.option.I_don_t_know: Ik weet het niet
+      field.OT05.label.When_did_you_last_have_your: Wanneer heeft u voor het laatst uw ogen laten controleren door een oogarts?
+      field.OT05.option.Less_than_1_year_ago: Minder dan 1 jaar geleden
+      field.OT05.option.1_to_2_years_ago: 1 tot 2 jaar geleden
+      field.OT05.option.More_than_2_years_ago: Meer dan 2 jaar geleden
+      field.OT05.option.I_have_never_had_a_check_up: Ik heb nooit een controle laten doen
+      field.OT05.option.I_don_t_remember: Ik weet het niet meer
+      field.OT06.label.Have_you_ever_had_a_major: Heeft u ooit een belangrijke operatie ondergaan?
+      field.OT06.option.Yes: Ja
+      field.OT06.option.No: Nee
+      field.OT06.option.I_don_t_remember: Ik weet het niet meer
+      field.OT07.label.Which_one_if_you_remember: Welke (als u het zich herinnert)?
+      group.Family_history: Familiegeschiedenis
+      field.FA00.label.The_following_questions_concern: De volgende vragen gaan over bepaalde ziekten die kunnen voorkomen in uw naaste familie (ouders, broers en zussen).
+      field.FA01.label.Has_a_close_family_member_had: Heeft een lid van uw naaste familie een cardiovasculaire ziekte (hartinfarct, CVA, plotse dood) gehad op jonge leeftijd?
+      field.FA01.option.Yes: Ja
+      field.FA01.option.No: Nee
+      field.FA01.option.I_don_t_know: Ik weet het niet
+      field.FA02.label.Is_there_a_history_of_cancer_in: Komt er in uw naaste familie kanker voor (borst, eierstok, prostaat, colorectaal, alvleesklier)?
+      field.FA02.option.Yes: Ja
+      field.FA02.option.No: Nee
+      field.FA02.option.I_don_t_know: Ik weet het niet
+      field.FA03.label.Do_close_family_members_have: Hebben leden van uw naaste familie diabetes type 2?
+      field.FA03.option.Yes: Ja
+      field.FA03.option.No: Nee
+      field.FA03.option.I_don_t_know: Ik weet het niet
+      section.Dental_Health: Tandgezondheid
+      field.DHDC01.label.How_often_do_you_usually_brush: Hoe vaak poetst u gewoonlijk uw tanden?
+      field.DHDC01.option.More_than_twice_a_day: Meer dan twee keer per dag
+      field.DHDC01.option.Twice_a_day: Twee keer per dag
+      field.DHDC01.option.Once_a_day: Eén keer per dag
+      field.DHDC01.option.Less_than_once_a_day: Minder dan eenmaal per dag
+      field.DHDC01.option.Never: Nooit
+      field.DHDC01.option.Not_applicable_according_to: Niet van toepassing (volgens de respondent)
+      field.DHDC02.label.Overall_how_would_you_rate_the: Hoe zou u over het algemeen de toestand van uw tanden en tandvlees beoordelen?
+      field.DHDC02.option.Very_good: Zeer goed
+      field.DHDC02.option.Good: Goed
+      field.DHDC02.option.Neither_good_nor_bad: Noch goed, noch slecht
+      field.DHDC02.option.Bad: Slecht
+      field.DHDC02.option.Very_bad: Zeer slecht
+      field.DHDC03.label.In_the_past_12_months_have_you: Heeft u in de afgelopen 12 maanden pijn in uw mond gehad?
+      field.DHDC03.option.Yes: Ja
+      field.DHDC03.option.No: Nee
+      field.DHDC04.label.When_did_you_last_visit_your: Wanneer heeft u voor het laatst uw tandarts of orthodontist bezocht?
+      field.DHDC04.option.Less_than_6_months_ago: Minder dan 6 maanden geleden
+      field.DHDC04.option.6_months_or_more_ago_but_less: 6 maanden of meer geleden, maar minder dan 12 maanden.
+      field.DHDC04.option.12_months_or_more_ago: 12 maanden of meer geleden
+      field.DHDC04.option.Never: Nooit
+      field.DHDC04.option.Don_t_know: Weet niet
+      section.Cancer_Screening: Kankerscreening
+      group.Family_history_of_cancer: Familiale voorgeschiedenis van kanker
+      field.SC02.label.Is_there_a_history_of_cancer_in: Komt er in uw naaste familie kanker voor (borst, eierstok, prostaat, colorectaal, alvleesklier)?
+      field.SC02.option.Yes: Ja
+      field.SC02.option.No: Nee
+      field.SC02.option.I_don_t_know: Ik weet het niet
+      group.Prostate_cancer.: Prostaatkanker.
+      field.SC20.label.IPSS_International_Prostate: "IPSS: International Prostate Score Symptom"
+      field.SC21.label.In_the_past_month_how_often: In de afgelopen maand, hoe vaak had u het gevoel dat uw blaas niet volledig leeg was na het plassen?
+      field.SC21.option.Never: Nooit
+      field.SC21.option.About_1_time_in_5: Ongeveer 1 op 5 keer
+      field.SC21.option.About_1_time_in_3: Ongeveer 1 op 3 keer
+      field.SC21.option.About_1_time_in_2: Ongeveer 1 op 2 keer
+      field.SC21.option.About_2_times_in_3: Ongeveer 2 op 3 keer
+      field.SC21.option.Almost_always: Bijna altijd
+      field.SC22.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand minder dan 2 uur na het plassen opnieuw moeten plassen?
+      field.SC22.option.Never: Nooit
+      field.SC22.option.About_1_time_in_5: Ongeveer 1 op 5 keer
+      field.SC22.option.About_1_time_in_3: Ongeveer 1 op 3 keer
+      field.SC22.option.About_1_time_in_2: Ongeveer 1 op 2 keer
+      field.SC22.option.About_2_times_in_3: Ongeveer 2 op 3 keer
+      field.SC22.option.Almost_always: Bijna altijd
+      field.SC23.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand een onderbreking van de urinestraal gehad, d.w.z. begin van het plassen, dan stoppen en dan opnieuw beginnen?
+      field.SC23.option.Never: Nooit
+      field.SC23.option.About_1_time_in_5: Ongeveer 1 op 5 keer
+      field.SC23.option.About_1_time_in_3: Ongeveer 1 op 3 keer
+      field.SC23.option.About_1_time_in_2: Ongeveer 1 op 2 keer
+      field.SC23.option.About_2_times_in_3: Ongeveer 2 op 3 keer
+      field.SC23.option.Almost_always: Bijna altijd
+      field.SC24.label.In_the_past_month_after_feeling: Hoe vaak heeft u in de afgelopen maand, nadat u de behoefte voelde om te plassen, moeite gehad om u in te houden?
+      field.SC24.option.Never: Nooit
+      field.SC24.option.About_1_time_in_5: Ongeveer 1 op 5 keer
+      field.SC24.option.About_1_time_in_3: Ongeveer 1 op 3 keer
+      field.SC24.option.About_1_time_in_2: Ongeveer 1 op 2 keer
+      field.SC24.option.About_2_times_in_3: Ongeveer 2 op 3 keer
+      field.SC24.option.Almost_always: Bijna altijd
+      field.SC25.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand een verminderde dikte of kracht van de urinestraal gehad?
+      field.SC25.option.Never: Nooit
+      field.SC25.option.About_1_time_in_5: Ongeveer 1 op 5 keer
+      field.SC25.option.About_1_time_in_3: Ongeveer 1 op 3 keer
+      field.SC25.option.About_1_time_in_2: Ongeveer 1 op 2 keer
+      field.SC25.option.About_2_times_in_3: Ongeveer 2 op 3 keer
+      field.SC25.option.Almost_always: Bijna altijd
+      field.SC26.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand moeten persen of duwen om te beginnen met plassen?
+      field.SC26.option.Never: Nooit
+      field.SC26.option.About_1_time_in_5: Ongeveer 1 op 5 keer
+      field.SC26.option.About_1_time_in_3: Ongeveer 1 op 3 keer
+      field.SC26.option.About_1_time_in_2: Ongeveer 1 op 2 keer
+      field.SC26.option.About_2_times_in_3: Ongeveer 2 op 3 keer
+      field.SC26.option.Almost_always: Bijna altijd
+      field.SC27.label.In_the_past_month_how_many: Hoe vaak per nacht bent u in de afgelopen maand gemiddeld opgestaan om te plassen (tussen het moment van naar bed gaan 's avonds en het definitief opstaan 's ochtends)?
+      field.SC27.option.Never: Nooit
+      field.SC27.option.1_time: 1 keer
+      field.SC27.option.2_times: 2 keer
+      field.SC27.option.3_times: 3 keer
+      field.SC27.option.4_times: 4 keer
+      field.SC27.option.5_times: 5 keer
+      field.SC28.label.Total_score: "Totaalscore:"
+      field.SC29.label.IPSS_notes_0_7_mild_8_19: "IPSS scores: 0 – 7 = licht; 8 – 19 = matig; 20 – 35 = ernstig"
+      group.Colorectal_cancer_screening: "Screening op colorectale kanker:"
+      field.SC31.label.There_is_a_screening_test_for: Er bestaat een screeningstest voor darmkanker (colorectaal) die het aanwezig zijn van bloed in de ontlasting opsporen. Heeft u ooit zo'n test ondergaan?
+      field.SC31.option.Yes: Ja
+      field.SC31.option.No: Nee
+      field.SC32.label.When_did_you_last_have_a_test: Wanneer heeft u voor het laatst een test gehad om bloed in de ontlasting op te sporen?
+      field.SC32.option.Less_than_2_years_ago: Minder dan 2 jaar geleden
+      field.SC32.option.2_years_or_more_ago: 2 jaar of meer geleden
+      field.SC32.option.Never: Nooit
+      field.SC32.option.I_don_t_know: Ik weet het niet
+      field.SC33.label.A_more_thorough_examination: Een geavanceerder onderzoek bestaat uit een inwendig onderzoek (endoscopie) van de darm met een sonde. Dit wordt een "colonoscopie" genoemd. Heeft u ooit een colonoscopie gehad?
+      field.SC33.option.Yes: Ja
+      field.SC33.option.No: Nee
+      field.SC34.label.When_did_you_last_have_a: Wanneer heeft u voor het laatst een colonoscopie gehad?
+      field.SC34.option.Less_than_5_years_ago: Minder dan 5 jaar geleden
+      field.SC34.option.More_than_5_years_ago_but_less: Meer dan 5 jaar maar minder dan 10 jaar geleden
+      field.SC34.option.More_than_10_years_ago: Meer dan 10 jaar geleden
+      group.Breast_cancer_screening: "Screening op borstkanker:"
+      field.SC36.label.Have_you_ever_had_a_mammography: Heeft u ooit een mammografie (röntgenonderzoek van één of beide borsten) ondergaan?
+      field.SC36.option.Yes: Ja
+      field.SC36.option.No: Nee
+      field.SC36.option.I_don_t_know: Ik weet het niet
+      field.SC37.label.When_did_you_last_have_a: Wanneer heeft u voor het laatst een mammografie gehad?
+      field.SC37.option.Less_than_2_years_ago: Minder dan 2 jaar geleden
+      field.SC37.option.2_years_or_more_ago: 2 jaar of meer geleden
+      field.SC37.option.I_don_t_know: Ik weet het niet
+      group.Cervical_cancer_screening: "Screening op baarmoederhalskanker:"
+      field.SC39.label.Have_you_ever_had_a_cervical: Heeft u ooit een cervixuitstrijkje (Pap-test) laten doen?
+      field.SC39.option.Yes: Ja
+      field.SC39.option.No: Nee
+      field.SC40.label.When_did_you_last_have_a: Wanneer heeft u voor het laatst een cervixuitstrijkje laten doen?
+      field.SC40.option.Less_than_3_years_ago: Minder dan 3 jaar geleden
+      field.SC40.option.3_years_or_more_ago: 3 jaar of meer geleden
+      field.SC40.option.I_don_t_know: Ik weet het niet
+      group.Skin_cancer: Huidkanker
+      field.SC42.label.Do_you_have_more_than_50_moles: Heeft u meer dan 50 moedervlekken op uw lichaam?
+      field.SC42.option.Yes: Ja
+      field.SC42.option.No: Nee
+      field.SC42.option.I_don_t_know: Ik weet het niet
+      field.SC44.label.How_does_your_skin_generally: Hoe reageert uw huid gewoonlijk op de zon?
+      field.SC44.option.I_burn_easily_I_tan_little_or: Ik verbrand gemakkelijk, ik word weinig of niet bruin
+      field.SC44.option.I_sometimes_burn_then_tan: Ik verbrand soms en word dan bruin
+      field.SC44.option.I_tan_easily_and_rarely_burn: Ik word gemakkelijk bruin en verbrand zelden
+      field.SC44.option.I_don_t_know: Ik weet het niet
+      field.SC45.label.Have_you_been_repeatedly: Bent u herhaaldelijk sterk blootgesteld geweest aan de zon gedurende uw leven? (buitenwerk, frequent buitenrecreatie in de zon, langdurige verblijven in zeer zonnige regio's, enz.)
+      field.SC45.option.Yes: Ja
+      field.SC45.option.No: Nee
+      field.SC45.option.I_don_t_know: Ik weet het niet
+      field.SC46.label.Have_you_ever_used_tanning_beds: Heeft u ooit zonnebanken (kunstmatige UV) gebruikt?
+      field.SC46.option.Never: Nooit
+      field.SC46.option.Occasionally: Af en toe
+      field.SC46.option.Regularly_in_the_past_or: Regelmatig (in het verleden of momenteel)
+      field.SC47.label.Have_you_ever_had_your_moles_or: Heeft u ooit uw moedervlekken of huid laten onderzoeken door een arts of dermatoloog?
+      field.SC47.option.Yes: Ja
+      field.SC47.option.No: Nee
+      field.SC47.option.I_don_t_know: Ik weet het niet
+      group.Lung_cancer: Longkanker
+      field.SC48.label.Have_you_smoked_the_equivalent: "Heeft u minstens het equivalent van één pakje per dag gedurende 20 jaar (of langer) gerookt? (of equivalent: bijv. 2 pakjes/dag gedurende 10 jaar)"
+      field.SC48.option.Yes: Ja
+      field.SC48.option.No: Nee
+      field.SC48.option.I_don_t_know: Ik weet het niet
+      section.Cardiovascular_Diseases: Hart- en Vaatziekten
+      field.PR01.label.Has_your_blood_pressure_ever: Is uw bloeddruk ooit gemeten door een arts, verpleegkundige of een andere zorgverlener?
+      field.PR01.option.Yes: Ja
+      field.PR01.option.No: Nee
+      field.PR01.option.I_don_t_know: Ik weet het niet
+      field.PR03.label.If_your_blood_pressure_was: Als uw bloeddruk minder dan een jaar geleden is gemeten, herinnert u zich hoeveel die was?
+      field.PR03.option.Above_140_90_mmHg: Hoger dan 140/90 mmHg
+      field.PR03.option.Between_120_70_and_140_90_mmHg: Tussen 120/70 en 140/90 mmHg
+      field.PR03.option.Below_120_70_mmHg: Lager dan 120/70 mmHg
+      field.PR03.option.I_don_t_remember: Ik weet het niet meer
+      field.PR04.label.When_did_you_last_have_a_blood: Wanneer heeft u voor het laatst een bloedonderzoek laten doen?
+      field.PR04.option.Less_than_a_year_ago: Minder dan een jaar
+      field.PR04.option.More_than_1_year_ago: Meer dan 1 jaar geleden
+      field.PR04.option.I_don_t_remember: Ik weet het niet meer
+      section.Physical_Pain: Fysieke Pijn
+      field.PI02.label.Do_you_currently_experience: Ervaart u momenteel aanhoudende pijn (sinds 3 maanden of meer) die een impact heeft op uw dagelijks leven of uw werk?
+      field.PI02.option.Yes: Ja
+      field.PI02.option.No: Nee
+      section.Mental_Health: Geestelijke Gezondheid
+      group.Perceived_stress: Ervaren stress
+      field.SM02.label.In_the_past_month_how_often: Hoe vaak bent u in de afgelopen maand van streek geraakt door een onverwachte gebeurtenis?
+      field.SM02.option.Never: Nooit
+      field.SM02.option.Almost_never: Bijna nooit
+      field.SM02.option.Sometimes: Soms
+      field.SM02.option.Often: Vaak
+      field.SM02.option.Very_often: Zeer vaak
+      field.SM03.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand het gevoel gehad de belangrijke dingen in uw leven niet te kunnen beheersen?
+      field.SM03.option.Never: Nooit
+      field.SM03.option.Almost_never: Bijna nooit
+      field.SM03.option.Sometimes: Soms
+      field.SM03.option.Often: Vaak
+      field.SM03.option.Very_often: Zeer vaak
+      field.SM04.label.In_the_past_month_how_often: Hoe vaak heeft u zich in de afgelopen maand nerveus en gestrest gevoeld?
+      field.SM04.option.Never: Nooit
+      field.SM04.option.Almost_never: Bijna nooit
+      field.SM04.option.Sometimes: Soms
+      field.SM04.option.Often: Vaak
+      field.SM04.option.Very_often: Zeer vaak
+      field.SM05.label.In_the_past_month_how_often: Hoe vaak heeft u zich in de afgelopen maand zelfverzekerd gevoeld over uw vermogen om uw persoonlijke problemen aan te pakken?
+      field.SM05.option.Never: Nooit
+      field.SM05.option.Almost_never: Bijna nooit
+      field.SM05.option.Sometimes: Soms
+      field.SM05.option.Often: Vaak
+      field.SM05.option.Very_often: Zeer vaak
+      field.SM06.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand het gevoel gehad dat de dingen uw kant opgingen?
+      field.SM06.option.Never: Nooit
+      field.SM06.option.Almost_never: Bijna nooit
+      field.SM06.option.Sometimes: Soms
+      field.SM06.option.Often: Vaak
+      field.SM06.option.Very_often: Zeer vaak
+      field.SM07.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand vastgesteld dat u niet alles aankon wat u moest doen?
+      field.SM07.option.Never: Nooit
+      field.SM07.option.Almost_never: Bijna nooit
+      field.SM07.option.Sometimes: Soms
+      field.SM07.option.Often: Vaak
+      field.SM07.option.Very_often: Zeer vaak
+      field.SM08.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand de ergernissen in uw leven kunnen beheersen?
+      field.SM08.option.Never: Nooit
+      field.SM08.option.Almost_never: Bijna nooit
+      field.SM08.option.Sometimes: Soms
+      field.SM08.option.Often: Vaak
+      field.SM08.option.Very_often: Zeer vaak
+      field.SM09.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand het gevoel gehad dat u de zaken onder controle had?
+      field.SM09.option.Never: Nooit
+      field.SM09.option.Almost_never: Bijna nooit
+      field.SM09.option.Sometimes: Soms
+      field.SM09.option.Often: Vaak
+      field.SM09.option.Very_often: Zeer vaak
+      field.SM10.label.In_the_past_month_how_often: Hoe vaak bent u in de afgelopen maand geïrriteerd geraakt door dingen die buiten uw controle plaatsvonden?
+      field.SM10.option.Never: Nooit
+      field.SM10.option.Almost_never: Bijna nooit
+      field.SM10.option.Sometimes: Soms
+      field.SM10.option.Often: Vaak
+      field.SM10.option.Very_often: Zeer vaak
+      field.SM11.label.In_the_past_month_how_often: Hoe vaak heeft u in de afgelopen maand het gevoel gehad dat de moeilijkheden zich zo hoog opstapelden dat u ze niet kon overwinnen?
+      field.SM11.option.Never: Nooit
+      field.SM11.option.Almost_never: Bijna nooit
+      field.SM11.option.Sometimes: Soms
+      field.SM11.option.Often: Vaak
+      field.SM11.option.Very_often: Zeer vaak
+      field.SM12.label.Total_score: "Totaalscore:"
+      group.Overall_well_being_energy_and: Algemeen welzijn, energie en vermoeidheid
+      field.SM14.label.On_a_scale_of_0_to_10_where_0: Op een schaal van 0 tot 10, waarbij 0 betekent “helemaal niet tevreden” en 10 betekent “volledig tevreden”, hoe tevreden bent u momenteel met uw leven?
+      field.SM15.label.In_recent_weeks_to_what_extent: In welke mate heeft u zich de afgelopen weken energiek of dynamisch gevoeld?
+      field.SM16.label.In_recent_weeks_to_what_extent: In welke mate heeft u zich de afgelopen weken moe of uitgeput gevoeld?
+      group.GAD_7_Scale_anxiety_disorder: GAD-7 schaal, screening op angststoornis
+      field.SM35.label.Over_the_last_2_weeks_how_often: In de afgelopen 2 weken, hoe vaak heeft u last gehad van de volgende problemen?
+      field.SM36.label.Feeling_nervous_anxious_or_on: Zich nerveus, angstig of gespannen voelen
+      field.SM36.option.Never: Nooit
+      field.SM36.option.Several_days: Meerdere dagen
+      field.SM36.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM36.option.Nearly_every_day: Bijna elke dag
+      field.SM37.label.Not_being_able_to_stop_or: Niet in staat zijn om met zorgen te stoppen of zorgen onder controle te houden
+      field.SM37.option.Never: Nooit
+      field.SM37.option.Several_days: Meerdere dagen
+      field.SM37.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM37.option.Nearly_every_day: Bijna elke dag
+      field.SM38.label.Worrying_too_much_about: Buitensporig piekeren over verschillende dingen
+      field.SM38.option.Never: Nooit
+      field.SM38.option.Several_days: Meerdere dagen
+      field.SM38.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM38.option.Nearly_every_day: Bijna elke dag
+      field.SM39.label.Trouble_relaxing: Moeite met ontspannen
+      field.SM39.option.Never: Nooit
+      field.SM39.option.Several_days: Meerdere dagen
+      field.SM39.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM39.option.Nearly_every_day: Bijna elke dag
+      field.SM40.label.Being_so_restless_that_it_is: Zo rusteloos dat het moeilijk is om stil te zitten
+      field.SM40.option.Never: Nooit
+      field.SM40.option.Several_days: Meerdere dagen
+      field.SM40.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM40.option.Nearly_every_day: Bijna elke dag
+      field.SM41.label.Becoming_easily_annoyed_or: De neiging om snel geïrriteerd of prikkelbaar te zijn
+      field.SM41.option.Never: Nooit
+      field.SM41.option.Several_days: Meerdere dagen
+      field.SM41.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM41.option.Nearly_every_day: Bijna elke dag
+      field.SM42.label.Feeling_afraid_as_if_something: Een gevoel van angst alsof er iets vreselijks zou kunnen gebeuren
+      field.SM42.option.Never: Nooit
+      field.SM42.option.Several_days: Meerdere dagen
+      field.SM42.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM42.option.Nearly_every_day: Bijna elke dag
+      field.SM43.label.Total_score: "Totaalscore:"
+      group.PHQ_9_Scale_depression_screening: PHQ-9 schaal, screening op depressie
+      field.SM45.label.Please_answer_each_question_by: Beantwoord elke vraag door de verklaring te selecteren die het beste bij uw situatie aansluit
+      field.SM46.label.Over_the_last_two_weeks_how: Hoe vaak heeft u in de afgelopen twee weken last gehad van de volgende problemen?
+      field.SM47.label.Little_interest_or_pleasure_in: Weinig interesse of plezier in dingen doen
+      field.SM47.option.Never: Nooit
+      field.SM47.option.Several_days: Meerdere dagen
+      field.SM47.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM47.option.Nearly_every_day: Bijna elke dag
+      field.SM48.label.Feeling_down_depressed_or: Zich verdrietig, neerslachtig of hopeloos voelen
+      field.SM48.option.Never: Nooit
+      field.SM48.option.Several_days: Meerdere dagen
+      field.SM48.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM48.option.Nearly_every_day: Bijna elke dag
+      field.SM49.label.Trouble_falling_asleep_staying: Moeite met inslapen, doorslapen of te veel slapen
+      field.SM49.option.Never: Nooit
+      field.SM49.option.Several_days: Meerdere dagen
+      field.SM49.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM49.option.Nearly_every_day: Bijna elke dag
+      field.SM50.label.Feeling_tired_or_having_little: Zich vermoeid voelen of weinig energie hebben
+      field.SM50.option.Never: Nooit
+      field.SM50.option.Several_days: Meerdere dagen
+      field.SM50.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM50.option.Nearly_every_day: Bijna elke dag
+      field.SM51.label.Poor_appetite_or_overeating: Slechte eetlust of overmatig eten
+      field.SM51.option.Never: Nooit
+      field.SM51.option.Several_days: Meerdere dagen
+      field.SM51.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM51.option.Nearly_every_day: Bijna elke dag
+      field.SM52.label.Feeling_bad_about_yourself_or: Zich slecht over jezelf voelen, of dat je een mislukking bent of jezelf of je familie teleur hebt gesteld
+      field.SM52.option.Never: Nooit
+      field.SM52.option.Several_days: Meerdere dagen
+      field.SM52.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM52.option.Nearly_every_day: Bijna elke dag
+      field.SM53.label.Trouble_concentrating_on_things: Moeite om u te concentreren op dingen zoals de krant lezen of televisie kijken
+      field.SM53.option.Never: Nooit
+      field.SM53.option.Several_days: Meerdere dagen
+      field.SM53.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM53.option.Nearly_every_day: Bijna elke dag
+      field.SM54.label.Moving_or_speaking_so_slowly: U beweegt of spreekt zo langzaam dat anderen het hebben kunnen opmerken. Of het tegenovergestelde — u bent zo rusteloos dat u veel meer beweegt dan gebruikelijk.
+      field.SM54.option.Never: Nooit
+      field.SM54.option.Several_days: Meerdere dagen
+      field.SM54.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM54.option.Nearly_every_day: Bijna elke dag
+      field.SM55.label.Thoughts_that_you_would_be: Gedachten dat u beter dood zou zijn of jezelf op de een of andere manier zou kunnen verwonden.
+      field.SM55.option.Never: Nooit
+      field.SM55.option.Several_days: Meerdere dagen
+      field.SM55.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM55.option.Nearly_every_day: Bijna elke dag
+      field.SM56.label.Total_score: "Totaalscore:"
+      field.SM57.label.If_the_patient_answers_yes_to: Als de patiënt ja antwoordt op vraag 9, wordt een beoordeling van zelfmoord- of zelfbeschadigingsrisico door een gekwalificeerde gezondheids- of sociaalwerker aanbevolen.
+      field.SM58.label.If_you_checked_off_any_problems: "Als u minstens een van de genoemde problemen in deze vragenlijst heeft aangevinkt, beantwoord dan de volgende vraag: In welke mate hebben dit probleem of deze problemen het moeilijk gemaakt om uw werk te doen, uw taken thuis uit te voeren of goed met anderen om te gaan?"
+      field.SM58.option.Not_difficult_at_all: Helemaal niet moeilijk
+      field.SM58.option.Somewhat_difficult: Eerder moeilijk
+      field.SM58.option.Very_difficult: Zeer moeilijk
+      field.SM58.option.Extremely_difficult: Extreem moeilijk
+      group.Depression_and_anxiety_disorders: Depressie en angststoornissen
+      field.SM60.label.Over_the_last_2_weeks_how_often: "Hoe vaak heeft u in de afgelopen 2 weken moeilijkheden ondervonden zoals:"
+      field.SM61.label.Feeling_nervous_anxious_or_on: Zich nerveus, angstig of gespannen voelen
+      field.SM61.option.Not_at_all: Helemaal niet
+      field.SM61.option.Several_days: Meerdere dagen
+      field.SM61.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM61.option.Nearly_every_day: Bijna elke dag
+      field.SM62.label.Not_being_able_to_stop_or: Niet kunnen stoppen met piekeren of uw zorgen niet onder controle kunnen houden
+      field.SM62.option.Not_at_all: Helemaal niet
+      field.SM62.option.Several_days: Meerdere dagen
+      field.SM62.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM62.option.Nearly_every_day: Bijna elke dag
+      field.SM63.label.Worrying_too_much_about: Zich te veel zorgen maken over verschillende dingen
+      field.SM63.option.Not_at_all: Helemaal niet
+      field.SM63.option.Several_days: Meerdere dagen
+      field.SM63.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM63.option.Nearly_every_day: Bijna elke dag
+      field.SM64.label.Having_trouble_relaxing: Moeite hebben om te ontspannen
+      field.SM64.option.Not_at_all: Helemaal niet
+      field.SM64.option.Several_days: Meerdere dagen
+      field.SM64.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM64.option.Nearly_every_day: Bijna elke dag
+      field.SM65.label.Being_so_restless_that_it_is: Zo rusteloos dat het moeilijk is om stil te zitten
+      field.SM65.option.Not_at_all: Helemaal niet
+      field.SM65.option.Several_days: Meerdere dagen
+      field.SM65.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM65.option.Nearly_every_day: Bijna elke dag
+      field.SM66.label.Being_easily_annoyed_or: Snel geïrriteerd of prikkelbaar zijn
+      field.SM66.option.Not_at_all: Helemaal niet
+      field.SM66.option.Several_days: Meerdere dagen
+      field.SM66.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM66.option.Nearly_every_day: Bijna elke dag
+      field.SM67.label.Feeling_afraid_as_if_something: Zich angstig voelen, alsof er iets vreselijks zou gaan gebeuren
+      field.SM67.option.Not_at_all: Helemaal niet
+      field.SM67.option.Several_days: Meerdere dagen
+      field.SM67.option.More_than_half_the_days: Meer dan de helft van de tijd
+      field.SM67.option.Nearly_every_day: Bijna elke dag
+      section.Physical_Activity: Fysieke Activiteit
+      field.PA01.label.The_following_questions_concern: De volgende vragen gaan over uw fysieke activiteiten gedurende een normale week, of dit nu op het werk, onderweg of in uw vrije tijd is.
+      group.Work_and_Daily_Activities: Werk en dagelijkse activiteiten
+      field.PA05.label.Generally_speaking_would_you: "Zou u in het algemeen zeggen dat u lichamelijk:"
+      field.PA05.option.Very_inactive: Zeer weinig actief
+      field.PA05.option.Moderately_active: Matig actief
+      field.PA05.option.Active: Actief
+      field.PA05.option.Very_active: Zeer actief
+      group.Commuting_and_Transport: Verplaatsingen en transport
+      field.PA08.label.In_a_typical_week_how_many_days: Hoeveel dagen per week beoefent u minstens 30 minuten matige of intensieve fysieke activiteit? (snel wandelen, fietsen, sport, fitness, zwemmen, joggen, enz.)
+      field.PA08.option.0_days: 0 dagen
+      field.PA08.option.1_to_2_days: 1 tot 2 dagen
+      field.PA08.option.3_to_4_days: 3 tot 4 dagen
+      field.PA08.option.5_days_or_more: 5 dagen of meer
+      field.PA09.label.Do_you_regularly_engage_in_a: Beoefent u regelmatig een sport- of vrijetijdsactiviteit?
+      field.PA09.option.No: Nee
+      field.PA09.option.Yes_occasionally: Ja, af en toe
+      field.PA09.option.Yes_1_to_2_times_per_week: Ja, 1 tot 2 keer per week
+      field.PA09.option.Yes_3_times_per_week_or_more: Ja, 3 keer per week of meer
+      field.PA10.label.In_a_typical_week_how_many_days: Hoeveel dagen per week doet u spieropbouwende oefeningen? (gewichtheffen, core-oefeningen, weerstandsoefeningen, enz.)
+      field.PA10.option.0_days: 0 dagen
+      field.PA10.option.1_day: 1 dag
+      field.PA10.option.2_days: 2 dagen
+      field.PA10.option.3_days_or_more: 3 dagen of meer
+      field.PA11.label.On_a_typical_day_how_much_time: Hoeveel tijd brengt u op een normale dag zittend of liggend door (exclusief slaap)? (op het werk, thuis, in vervoer, voor een scherm, enz.)
+      field.PA11.option.Less_than_6_hours_per_day: Minder dan 6 uur per dag
+      field.PA11.option.6_to_8_hours_per_day: 6 tot 8 uur per dag
+      field.PA11.option.8_to_10_hours_per_day: 8 tot 10 uur per dag
+      field.PA11.option.More_than_10_hours_per_day: Meer dan 10 uur per dag
+      field.PA12.label.Is_your_work_physically: Is uw beroepsactiviteit fysiek veeleisend?
+      field.PA12.option.No_mainly_seated_or_standing: Nee, voornamelijk zittend of staand
+      field.PA12.option.Yes_moderately_active_walking: Ja, matig actief (wandelen, frequente verplaatsingen)
+      field.PA12.option.Yes_physically_demanding: Ja, fysiek veeleisend
+      section.Nutritional_Habits: Voedingsgewoonten
+      field.NH01.label.How_often_do_you_eat_fruit: Hoe vaak eet u fruit? Versgeperste fruitsappen, sappen op basis van concentraat of verwerkt fruit en gezoete sappen zijn niet inbegrepen
+      field.NH01.option.Every_day: Elke dag
+      field.NH01.option.4_to_6_times_per_week: 4 tot 6 keer per week
+      field.NH01.option.1_to_3_times_per_week: 1 tot 3 keer per week
+      field.NH01.option.Less_than_once_a_week: Minder dan één keer per week
+      field.NH01.option.Never: Nooit
+      field.NH02.label.How_often_do_you_eat_vegetables: Hoe vaak eet u groenten of salade? (Exclusief aardappelen, soepen en sappen)
+      field.NH02.option.Every_day: Elke dag
+      field.NH02.option.4_to_6_times_per_week: 4 tot 6 keer per week
+      field.NH02.option.1_to_3_times_per_week: 1 tot 3 keer per week
+      field.NH02.option.Less_than_once_a_week: Minder dan één keer per week
+      field.NH02.option.Never: Nooit
+      field.NH03.label.How_often_do_you_drink_sugary: Hoe vaak drinkt u gezoete dranken (frisdrank, limonade, ijsthee, gezoete sappen)? (Exclusief light-/zeroproducten)
+      field.NH03.option.Every_day: Elke dag
+      field.NH03.option.4_to_6_times_per_week: 4 tot 6 keer per week
+      field.NH03.option.1_to_3_times_per_week: 1 tot 3 keer per week
+      field.NH03.option.Less_than_once_a_week: Minder dan één keer per week
+      field.NH03.option.Never: Nooit
+      field.NH04.label.How_often_do_you_eat_sweet_or: Hoe vaak eet u zoete of zoute snacks (snoep, chocolade, gebak, koekjes, chips…)?
+      field.NH04.option.Every_day: Elke dag
+      field.NH04.option.4_to_6_times_per_week: 4 tot 6 keer per week
+      field.NH04.option.1_to_3_times_per_week: 1 tot 3 keer per week
+      field.NH04.option.Less_than_once_a_week: Minder dan één keer per week
+      field.NH04.option.Never: Nooit
+      field.NH05.label.On_average_how_much_water_do: Hoeveel water drinkt u gemiddeld per dag (exclusief koffie, thee, frisdrank, alcohol)?
+      field.NH05.option.Less_than_1_litre: Minder dan 1 liter
+      field.NH05.option.About_1_to_1.5_litres: Ongeveer 1 tot 1,5 liter
+      field.NH05.option.More_than_1.5_litres: Meer dan 1,5 liter
+      field.NH05.option.I_don_t_know: Ik weet het niet
+      field.NH06.label.How_often_do_you_eat_breakfast: Hoe vaak ontbijt u ('s ochtends)?
+      field.NH06.option.Every_day: Elke dag
+      field.NH06.option.5_to_6_times_per_week: 5 tot 6 keer per week
+      field.NH06.option.2_to_4_times_per_week: 2 tot 4 keer per week
+      field.NH06.option.Rarely: Zelden
+      field.NH06.option.Never: Nooit
+      field.NH07.label.Do_you_snack_between_meals: Komt het voor dat u tussendoor snackt buiten de maaltijden?
+      field.NH07.option.Yes_often: Ja, vaak
+      field.NH07.option.Yes_sometimes: Ja, soms
+      field.NH07.option.No_rarely: Nee, zelden
+      field.NH07.option.No_never: Nee, nooit
+      field.NH08.label.How_often_do_you_eat_processed: Hoe vaak consumeert u verwerkte of ultraverwerkte voedingsproducten (kant-en-klaarmaaltijden, vleeswaren, diepvriespizza's, enz.)?
+      field.NH08.option.Very_often: Zeer vaak
+      field.NH08.option.Often: Vaak
+      field.NH08.option.Occasionally: Af en toe
+      field.NH08.option.Rarely: Zelden
+      field.NH08.option.Never: Nooit
+      field.NH09.label.How_often_do_you_eat_fast_food: Hoe vaak eet u fastfoodmaaltijden?
+      field.NH09.option.Several_times_per_week: Meerdere keren per week
+      field.NH09.option.About_once_a_week: Ongeveer 1 keer per week
+      field.NH09.option.1_to_3_times_per_month: 1 tot 3 keer per maand
+      field.NH09.option.Rarely: Zelden
+      field.NH09.option.Never: Nooit"
+      field.NH16.label.Do_you_have_any_food: Heeft u voedselintoleranties of voedselallergieën?
+      field.NH17.label.Which_foods_are_you_intolerant: Welke voedingsmiddelen verdraagt u niet of bent u allergisch voor? (Meerdere antwoorden mogelijk)
+      field.NH17.option.Milk_lactose: Melk (lactose)
+      field.NH17.option.Peanuts: Pinda's
+      field.NH17.option.Walnuts: Noten
+      field.NH17.option.Hazelnuts: Hazelnoten
+      field.NH17.option.Other_nuts: Andere noten
+      field.NH17.option.Shellfish: Schaaldieren
+      field.NH17.option.Soy: Soja
+      field.NH17.option.Gluten_containing_cereals: Glutenbevattende granen
+      field.NH17.option.Eggs: Eieren
+      field.NH17.option.Fish: Vis
+      field.NH17.option.Other_specify: "Andere, specificeer:"
+      field.NH18.label.Other_allergy_specify: "Andere allergie, specificeer:"
+      field.NH19.label.Has_this_milk_lactose: Is deze intolerantie of allergie voor melk (lactose) bevestigd door een arts?
+      field.NH19.option.Yes: Ja
+      field.NH19.option.No: Nee
+      field.NH19.option.Don_t_know: Weet niet
+      field.NH20.label.Has_this_peanut_intolerance_or: Is deze intolerantie of allergie voor pinda's bevestigd door een arts?
+      field.NH20.option.Yes: Ja
+      field.NH20.option.No: Nee
+      field.NH20.option.Don_t_know: Weet niet
+      field.NH21.label.Has_this_nut_intolerance_or: Is deze intolerantie of allergie voor noten bevestigd door een arts?
+      field.NH21.option.Yes: Ja
+      field.NH21.option.No: Nee
+      field.NH21.option.Don_t_know: Weet niet
+      field.NH22.label.Has_this_shellfish_intolerance: Is deze intolerantie of allergie voor schaaldieren bevestigd door een arts?
+      field.NH22.option.Yes: Ja
+      field.NH22.option.No: Nee
+      field.NH22.option.Don_t_know: Weet niet
+      field.NH23.label.Has_this_soy_intolerance_or: Is deze intolerantie of allergie voor soja bevestigd door een arts?
+      field.NH23.option.Yes: Ja
+      field.NH23.option.No: Nee
+      field.NH23.option.Don_t_know: Weet niet
+      field.NH24.label.Has_this_gluten_intolerance_or: Is deze intolerantie of allergie voor gluten bevestigd door een arts?
+      field.NH24.option.Yes: Ja
+      field.NH24.option.No: Nee
+      field.NH24.option.Don_t_know: Weet niet
+      field.NH25.label.Has_this_egg_intolerance_or: Is deze intolerantie of allergie voor eieren bevestigd door een arts?
+      field.NH25.option.Yes: Ja
+      field.NH25.option.No: Nee
+      field.NH25.option.Don_t_know: Weet niet
+      field.NH26.label.Has_this_fish_intolerance_or: Is deze intolerantie of allergie voor vis bevestigd door een arts?
+      field.NH26.option.Yes: Ja
+      field.NH26.option.No: Nee
+      field.NH26.option.Don_t_know: Weet niet
+      field.NH27.label.Has_another_intolerance_or: Is een andere intolerantie of allergie bevestigd door een arts?
+      section.Sleep_Quality: Slaapkwaliteit
+      field.CD01.label.This_questionnaire_assesses_the: Deze vragenlijst evalueert de kwaliteit van uw slaap
+      field.CD02.label.Do_you_have_trouble_falling: Heeft u moeite met inslapen?
+      field.CD02.option.Never: Nooit
+      field.CD02.option.Rarely: Zelden
+      field.CD02.option.Occasionally: Af en toe
+      field.CD02.option.Most_of_the_time: Meestal
+      field.CD02.option.Always: Altijd
+      field.CD03.label.Do_you_have_trouble_staying: Heeft u moeite om in slaap te blijven?
+      field.CD03.option.Never: Nooit
+      field.CD03.option.Rarely: Zelden
+      field.CD03.option.Occasionally: Af en toe
+      field.CD03.option.Most_of_the_time: Meestal
+      field.CD03.option.Always: Altijd
+      field.CD04.label.Do_you_take_medication_to_help: Neemt u medicijnen om u te helpen slapen?
+      field.CD04.option.Never: Nooit
+      field.CD04.option.Rarely: Zelden
+      field.CD04.option.Occasionally: Af en toe
+      field.CD04.option.Most_of_the_time: Meestal
+      field.CD04.option.Always: Altijd
+      field.CD05.label.Do_you_drink_alcohol_to_help: Drinkt u alcohol om u te helpen slapen?
+      field.CD05.option.Never: Nooit
+      field.CD05.option.Rarely: Zelden
+      field.CD05.option.Occasionally: Af en toe
+      field.CD05.option.Most_of_the_time: Meestal
+      field.CD05.option.Always: Altijd
+      field.CD06.label.Is_there_a_health_problem_that: Is er een gezondheidsprobleem dat uw slaap verstoort?
+      field.CD06.option.Never: Nooit
+      field.CD06.option.Rarely: Zelden
+      field.CD06.option.Occasionally: Af en toe
+      field.CD06.option.Most_of_the_time: Meestal
+      field.CD06.option.Always: Altijd
+      field.CD07.label.Have_you_lost_all_interest_in: Heeft u alle interesse verloren in uw activiteiten en hobby's?
+      field.CD07.option.Never: Nooit
+      field.CD07.option.Rarely: Zelden
+      field.CD07.option.Occasionally: Af en toe
+      field.CD07.option.Most_of_the_time: Meestal
+      field.CD07.option.Always: Altijd
+      field.CD08.label.Do_you_feel_sad_irritable_or: Voelt u zich verdrietig, prikkelbaar of hopeloos?
+      field.CD08.option.Never: Nooit
+      field.CD08.option.Rarely: Zelden
+      field.CD08.option.Occasionally: Af en toe
+      field.CD08.option.Most_of_the_time: Meestal
+      field.CD08.option.Always: Altijd
+      field.CD09.label.Do_you_feel_nervous_or_anxious: Voelt u zich nerveus of ongerust?
+      field.CD09.option.Never: Nooit
+      field.CD09.option.Rarely: Zelden
+      field.CD09.option.Occasionally: Af en toe
+      field.CD09.option.Most_of_the_time: Meestal
+      field.CD09.option.Always: Altijd
+      field.CD10.label.Do_you_think_there_is_something: Denkt u dat er iets mis is met uw lichaam?
+      field.CD10.option.Never: Nooit
+      field.CD10.option.Rarely: Zelden
+      field.CD10.option.Occasionally: Af en toe
+      field.CD10.option.Most_of_the_time: Meestal
+      field.CD10.option.Always: Altijd
+      field.CD11.label.Is_your_work_schedule_variable: Is uw werkschema wisselend? Is uw slaapritme veranderlijk?
+      field.CD11.option.Never: Nooit
+      field.CD11.option.Rarely: Zelden
+      field.CD11.option.Occasionally: Af en toe
+      field.CD11.option.Most_of_the_time: Meestal
+      field.CD11.option.Always: Altijd
+      field.CD12.label.Are_your_legs_restless_and_or: Zijn uw benen rusteloos en/of oncomfortabel voor het slapen?
+      field.CD12.option.Never: Nooit
+      field.CD12.option.Rarely: Zelden
+      field.CD12.option.Occasionally: Af en toe
+      field.CD12.option.Most_of_the_time: Meestal
+      field.CD12.option.Always: Altijd
+      field.CD13.label.Have_you_been_told_that_you_are: Heeft men u gezegd dat u rusteloos bent of schopt tijdens uw slaap?
+      field.CD13.option.Never: Nooit
+      field.CD13.option.Rarely: Zelden
+      field.CD13.option.Occasionally: Af en toe
+      field.CD13.option.Most_of_the_time: Meestal
+      field.CD13.option.Always: Altijd
+      field.CD14.label.Do_you_have_unusual_behaviours: Heeft u ongewone houdingen of bewegingen tijdens uw slaap?
+      field.CD14.option.Never: Nooit
+      field.CD14.option.Rarely: Zelden
+      field.CD14.option.Occasionally: Af en toe
+      field.CD14.option.Most_of_the_time: Meestal
+      field.CD14.option.Always: Altijd
+      field.CD15.label.Do_you_snore: Snurkt u?
+      field.CD15.option.Never: Nooit
+      field.CD15.option.Rarely: Zelden
+      field.CD15.option.Occasionally: Af en toe
+      field.CD15.option.Most_of_the_time: Meestal
+      field.CD15.option.Always: Altijd
+      field.CD16.label.Have_you_been_told_that_you: Heeft men u gezegd dat u stopt met ademen, snurkt of stikt in uw slaap?
+      field.CD16.option.Never: Nooit
+      field.CD16.option.Rarely: Zelden
+      field.CD16.option.Occasionally: Af en toe
+      field.CD16.option.Most_of_the_time: Meestal
+      field.CD16.option.Always: Altijd
+      field.CD17.label.Do_you_have_trouble_staying: Heeft u moeite om overdag wakker te blijven?
+      field.CD17.option.Never: Nooit
+      field.CD17.option.Rarely: Zelden
+      field.CD17.option.Occasionally: Af en toe
+      field.CD17.option.Most_of_the_time: Meestal
+      field.CD17.option.Always: Altijd
+      field.CD18.label.Total_score: "Totaalscore:"
+      group.Note_to_physician._Help_with: Opmerking voor de arts. Hulp bij de interpretatie van de resultaten
+      field.CD20.label.SO1_15_Insomnia: "SO1-15: Insomnia"
+      field.CD21.label.With_a_score_of_3_4_or_5_on_any: Bij een score van 3, 4 of 5 op om het even welke vraag lijdt de patiënt waarschijnlijk aan insomnia. Als zij 3, 4 of 5 antwoorden op twee of meer items en een significante overdag-beperking vertonen, vereist de insomnia een meer diepgaande evaluatie en behandeling
+      field.CD22.label.SO6_9_Mental_health_disorders: "SO6-9: Psychische stoornissen"
+      field.CD23.label.Scores_of_4_or_5_on_questions_6: Scores van 4 of 5 op vragen 6 tot 9 vereisen een meer diepgaande screening op psychiatrische stoornissen. Vraag 8 verwijst naar somatisatie en kan een onderliggende somatoforme stoornis weerspiegelen die specifieke behandeling vereist.
+      field.CD24.label.SO10_Circadian_rhythm_disorders: "SO10: Circadiane ritmestoornissen"
+      field.CD25.label.A_score_of_4_or_5_on_question: Een score van 4 of 5 op vraag 10 kan wijzen op een circadiane ritmestoornis. Verdere bevraging over ploegendienst of een voorkeur voor een vertraagde slaapfase.
+      field.CD26.label.SO11_12_Restless_legs_syndrome: "SO11-12: Rusteloze benen syndroom"
+      field.CD27.label.A_score_of_4_or_5_on_question: Een score van 4 of 5 op vraag 11 of 12 is significant en draagt waarschijnlijk bij aan symptomen van insomnia of niet-herstellende slaap. Vraag 11 verwijst naar het rusteloze benen syndroom en vraag 12 verwijst naar periodieke bewegingsstoornissen van de ledematen.
+      field.CD28.label.SO13_Parasomnias: "SO13: Parasomnieën"
+      field.CD29.label.A_score_of_2_to_5_on_question: Een score van 2 tot 5 op vraag 14 zou bezorgdheid moeten wekken, vooral als de gebeurtenis of beweging gewelddadig of potentieel verwondend is voor de patiënt of zijn/haar bedpartner.
+      field.CD30.label.SO14_16_Sleep_apnoea: "SO14-16: Slaapapneu"
+      field.CD31.label.A_score_of_4_or_5_on_question: Een score van 4 of 5 op vraag 14 of 15 vereist op zichzelf al een meer diepgaande klinische evaluatie van slaapapneu. Een score hoger dan 3 op vragen 14 en 15 of 14 en 16 is eveneens verdacht voor slaapapneu en een meer diepgaande evaluatie dient te worden uitgevoerd.
+      section.Dependencies: Verslavingen
+      group.Tobacco: Tabak
+      field.DEP01.label.Describe_your_smoking_behaviour: "Beschrijf uw rookgedrag:"
+      field.DEP01.option.I_have_never_smoked: Ik heb nooit gerookt
+      field.DEP01.option.I_used_to_smoke_but_I_have_quit: Ik heb gerookt, maar ik ben gestopt
+      field.DEP01.option.I_smoke: Ik rook
+      field.DEP11.label.How_many_years_ago_did_you_quit: Hoeveel jaar geleden bent u gestopt met roken?
+      field.DEP02.label.Amount_consumed: "Verbruikte hoeveelheid:"
+      field.DEP03.label.Duration_of_consumption_in_years: "Duur van het gebruik (in jaren):"
+      group.Alcohol: Alcohol
+      field.DEP04.label.Describe_your_alcohol: "Beschrijf uw alcoholconsumptie:"
+      field.DEP04.option.I_drink_alcohol: Ik drink alcohol
+      field.DEP04.option.I_have_never_consumed_alcohol: Ik heb nooit alcohol gedronken
+      field.DEP04.option.I_used_to_drink_alcohol_but_I: Ik dronk alcohol, maar ik ben gestopt
+      field.DEP12.label.How_many_years_ago_did_you_stop: Hoeveel jaar geleden bent u gestopt met het drinken van alcohol?
+      field.DEP05.label.Amount_consumed: "Verbruikte hoeveelheid:"
+      field.DEP06.label.Duration_of_consumption_in_years: "Duur van het gebruik (in jaren):"
+      section.General_Practitioner: Huisarts
+      field.GP01.label.Contact_with_a_general: Contact met een huisarts
+      field.GP02.label.Here_are_some_questions_about: "Hier zijn enkele vragen over uw gebruik van gezondheidszorgdiensten. Let op: dit betreft uw eigen gebruik van gezondheidszorgdiensten."
+      field.GP03.label.Do_you_have_a_regular_general: Heeft u een huisarts of een vaste groep huisartsen (dit kan een medisch centrum zijn)?
+      field.GP03.option.Yes: Ja
+      field.GP03.option.No: Nee
+      field.GP03.option.Don_t_know: Weet niet
+      field.GP04.label.The_following_questions_concern: De volgende vragen gaan over uw consulten met de huisarts. Dit omvat praktijkbezoeken, huisbezoeken en telefonische adviezen.
+      field.GP05.label.When_did_you_last_see_a_general: Wanneer heeft u voor het laatst een huisarts geraadpleegd?
+      field.GP05.option.Less_than_6_months_ago: Minder dan 6 maanden geleden
+      field.GP05.option.More_than_6_months_ago: Meer dan 6 maanden geleden
+      field.GP05.option.Never: Nooit
+      field.GP05.option.Don_t_know: Weet niet

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 		"uuid": "^9.0.1"
 	},
 	"devDependencies": {
+		"@axe-core/playwright": "^4.11.3",
 		"@babel/core": "^7.26.10",
 		"@babel/eslint-parser": "^7.26.10",
 		"@babel/traverse": "^7.26.10",

--- a/plans/patient-cards-renderer.md
+++ b/plans/patient-cards-renderer.md
@@ -1,0 +1,363 @@
+# Plan: patient-cards renderer
+
+> Source PRD: [icure/icure-form#3](https://github.com/icure/icure-form/issues/3) — patient-cards renderer (Typeform-style patient-facing form rendering)
+>
+> Follow-ups tracker: [icure/icure-form#4](https://github.com/icure/icure-form/issues/4)
+
+A Typeform-style alternate renderer for `@icure/form`, optimised for pre-visit patient intake. Activated by `<icure-form renderer="patient-cards">`. Ships in the same library; existing clinician renderer (`renderer="form"`) behaviour unchanged.
+
+## Phase status overview
+
+| Phase | Title                                                   | Status       | Tests                                   | Pass / Total |
+|-------|---------------------------------------------------------|--------------|-----------------------------------------|--------------|
+| 1     | Dispatch + nav + `hiddenForPatient` + Subform recursion | **Complete** | `test/e2e/patient-cards-phase1.spec.ts` | 21 / 21      |
+| 2     | Welcome + review + confirmation + `patient-form-submit` | **Complete** | `test/e2e/patient-cards-phase2.spec.ts` | 18 / 18      |
+| 3     | Per-card validation + cross-card deferred to review     | **Complete** | `test/e2e/patient-cards-phase3.spec.ts` | 10 / 10      |
+| 4     | Conditional re-evaluation with stay semantics           | **Complete** | `test/e2e/patient-cards-phase4.spec.ts` | 10 / 10      |
+| 5     | Auto fast-forward resume                                | **Complete** | `test/e2e/patient-cards-phase5.spec.ts` | 9 / 9        |
+| 6     | i18n patient-renderer chrome translation keys           | **Complete** | `test/e2e/patient-cards-phase6.spec.ts` | 5 / 5        |
+| 7     | Field-type coverage + `questionsPerCard=2`              | **Complete** | `test/e2e/patient-cards-phase7.spec.ts` | 10 / 10      |
+| 8     | Theme + animations + accessibility                      | **Complete** | `test/e2e/patient-cards-phase8.spec.ts` | 13 / 13      |
+
+**Combined total across all phases: 96 / 96 tests passing** (1.6 min on a single Playwright worker).
+
+Regression check: `test/e2e/forms.spec.ts` clinician renderer tests — 39 / 40 pass; the single failure (`Dynamic hidden fields / reveals allergy follow-up fields …`) references a missing `app/samples/preventi.yaml` and pre-dates this branch.
+
+## Architectural decisions
+
+Durable across all phases:
+
+- **Public API**: `<icure-form renderer="patient-cards">` activates the patient renderer via the existing `renderer`-prop dispatch in `<icure-form>`. New prop `questionsPerCard: 1 | 2` (default `1`) honoured only when `renderer="patient-cards"`.
+- **Schema additions**: optional `hiddenForPatient: boolean` (default `false` — opt-out) added to `Section`, `Group`, `Subform`, and `Field`. Round-trips through `.parse()` and `.toJson()`. Cascades through subtrees.
+- **Event surface**: one new custom event `patient-form-submit` with detail `{ submittedAt: Date }`, fired from `<icure-form>` when the patient confirms submit from the review card. No analytics events. Data mutations continue to flow through `FormValuesContainer.registerChangeListener`.
+- **Renderer location**: new render function under `src/components/icure-form/renderer/patient-cards/` alongside the existing `renderer/form/`. Dispatched from `<icure-form>`'s `renderer`-prop split (the same `variant[0]` switch that today only recognises `form`). The render function returns an internal stateful Lit element that owns card-index / navigation / animation state.
+- **Macro session structure**: welcome → linear card sequence → review → confirmation. Welcome / review / confirmation are not counted in the progress fraction.
+- **Auto-flatten algorithm**: walks the Form's Section/Group/Subform/Field tree depth-first; prunes elements with `hiddenForPatient: true` (cascade) and elements whose computed `hidden` evaluates truthy; recurses transparently through Subforms with a visited-set cycle guard; chunks interactive Fields into Cards of size ≤ `questionsPerCard`. Labels and read-only displays attach to the surrounding card without counting toward the limit. The pass re-runs after every Continue and every back-edit ("fully dynamic" with "stay" semantics — values preserved across re-flatten).
+- **Validation**: reuses existing per-field `validationErrorsProvider`. Validators are classified per render as currently-evaluable (dependencies on current-or-earlier cards) vs cross-card (dependencies on later cards). Strict per-card gating: Continue is disabled while any currently-evaluable validator on the current card fails. Cross-card validators are deferred to the review card and block Submit until cleared. No changes to the `Validator` interface.
+- **Resume**: auto fast-forward — on initial render, the renderer plays through the card sequence virtually, auto-advancing past cards whose interactive Fields are answered and validators pass; stops at the first uncovered/invalid card, or at review if input cards are all complete. Position is derived from data; no new persistence event or `resumeCardIndex` prop.
+- **Theme**: new `patient-cards` SCSS theme under `src/components/themes/`, mirroring existing theme structure. Composable via existing CSS custom property surface.
+- **i18n**: existing `language` + `translationProvider` reused. Documented translation keys for renderer-emitted chrome strings under the `patient-renderer.*` namespace, with English fallback when the provider returns the key unchanged.
+- **Host-app contract**: renderer is auth-agnostic. Host app provides a constructed `FormValuesContainer` (canonical pattern: token-scoped bounded delegation against a single `Contact`). Renderer does not write `AccessLog` entries; jurisdictional audit obligations live in the iCure bridge / host app.
+- **Accessibility target**: WCAG 2.1 AA. Mobile-responsive down to 360px. Keyboard navigation across all controls. Reduced-motion preference honoured.
+- **Test approach**: unit / integration tests in `test/icure-form/` using ts-jest, mirroring existing patterns (`test.spec.ts`, `subform-deletion.spec.ts`, `prosemirror.spec.ts`). End-to-end coverage via Playwright in `test/e2e/`.
+- **Out of scope** (tracked in follow-ups issue #4): per-card analytics events, explicit save-and-quit affordance, `visibleForPatient` opt-in alternative, file upload field, e-signature field, auto-advance on radio/dropdown selection.
+
+---
+
+## Phase 1: Renderer dispatch, linear card navigation, `hiddenForPatient` schema, Subform transparent recursion
+
+**Status: complete.** Tests in `test/e2e/patient-cards-phase1.spec.ts` — 21 / 21 passing.
+
+Test groups:
+
+- **dispatch (2 tests, 2 ✓)** — `renderer="patient-cards"` mounts the internal element; `renderer="form"` (default) does not.
+- **linear navigation (4 tests, 4 ✓)** — three cards from three text fields; Back hidden on first card; Continue/Back/Submit transitions; progress bar width tracks index (33% → 66% → 100%).
+- **`hiddenForPatient` cascade (6 tests, 6 ✓)** — Field-level only excludes that field; Group-level cascades; Section-level cascades; Subform-level cascades; nested-Group cascade; flag has no effect on clinician renderer.
+- **Subform recursion (3 tests, 3 ✓)** — inline merge between sibling fields; multiple form templates contribute fields from every template; cyclic references skipped with `console.warn` and finite card count.
+- **parse / `toJson` round-trip (5 tests, 5 ✓)** — `hiddenForPatient` round-trips at Field / Section / Group / Subform; absent flag remains falsy.
+- **rendering integration (1 test, 1 ✓)** — current card renders the expected field component (`<icure-form-text-field>` on card 0, `<icure-form-number-field>` on card 1).
+
+**User stories**:
+
+- As an integrator, I activate the patient renderer via `<icure-form renderer="patient-cards">` and the existing clinician renderer is untouched.
+- As a patient, I see one interactive Field at a time on a card and can navigate forward (Continue) and back (Back).
+- As a patient, I see a fractional progress bar reflecting my position.
+- As a form author, I mark any of Section / Group / Subform / Field as `hiddenForPatient: true` and the element and its entire subtree are excluded from the patient view.
+- As a form author, I use Subforms inside patient-bound forms and their contents are merged transparently into the patient's card sequence.
+
+### What to build
+
+A thin end-to-end tracer through dispatch, model, renderer, and tests. Extend `<icure-form>`'s `renderer` dispatch to recognise `patient-cards` and route to a new render function that returns an internal stateful element holding card-index / Continue / Back state. Implement the auto-flatten algorithm at its baseline shape: depth-first walk of Section → Group → Subform → Field, pruning elements with `hiddenForPatient: true`, recursing transparently through Subforms with a visited-set guard. Emit a non-functional submit at end (placeholder until phase 2). Add `hiddenForPatient` to the four model nodes with `parse()` / `toJson()` round-trip. No welcome / review / confirmation, no validation gating, no conditional re-evaluation, no animation, no theming polish — those layer on later. Naive chrome (unstyled or minimally styled) is sufficient.
+
+### Acceptance criteria
+
+- [ ] `<icure-form renderer="patient-cards" .form=${form} .formValuesContainer=${container}>` renders without errors against a fixture form.
+- [ ] `<icure-form>` (default or `renderer="form"`) is regression-free.
+- [ ] A form with N visible interactive Fields produces exactly N cards in patient mode, each showing one Field.
+- [ ] Continue advances to the next card; Back returns to the previous; Back is hidden on the first card.
+- [ ] Progress chrome shows correct `current / total` (input cards only; welcome / review / confirmation not yet present).
+- [ ] `hiddenForPatient: true` on a Section excludes that Section's contents from the patient sequence.
+- [ ] Cascade verified at Section, Group, Subform, and Field levels.
+- [ ] `hiddenForPatient` has no effect on the clinician renderer.
+- [ ] Subforms are recursed transparently — a Subform's Sections become cards as if at the parent level.
+- [ ] Circular Subform reference is detected by a visited-set guard and skipped with `console.warn`.
+- [ ] `Section.parse()`, `Group.parse()`, `Subform.parse()`, `Field.parse()` round-trip `hiddenForPatient` through `toJson()`.
+- [ ] Unit tests cover: dispatch, navigation, cascade at all four model nodes, Subform transparent recursion, cycle guard, parse/toJson round-trip.
+
+---
+
+## Phase 2: Welcome + review + confirmation + `patient-form-submit`
+
+**Status: complete.** Tests in `test/e2e/patient-cards-phase2.spec.ts` — 18 / 18 passing.
+
+Test groups:
+
+- **welcome card (6 tests, 6 ✓)** — initial stage is welcome; shows `Form.title` + `Form.description` + Start; Start advances to first input card; welcome not counted in progress; Back from first input returns to welcome; welcome renders when description is absent.
+- **card sequence → review (2 tests, 2 ✓)** — Continue on last input card transitions to review; progress chrome absent on review stage.
+- **review card (6 tests, 6 ✓)** — lists all field labels grouped by Section; shows actual entered values from the `FormValuesContainer`; empty values render an em-dash; Edit jumps to specific card with `cameFromReview` semantics (Continue button switches to "return to review" variant); Continue from edit-jumped card returns directly to review; Back from review goes to last input card.
+- **submit and confirmation (4 tests, 4 ✓)** — Submit fires `patient-form-submit` with `detail.submittedAt`; confirmation stage shown after submit with "Thank you" heading; no Back on confirmation; no progress chrome on confirmation.
+
+**User stories**:
+
+- As a patient, I see a welcome card with the form title and description before answering anything.
+- As a patient, I review all my answers before submitting, organised by Section.
+- As a patient, I jump from review back to any specific card to edit a single answer.
+- As a patient, I see a confirmation card after submitting.
+- As a host app, I receive a `patient-form-submit` event with `{ submittedAt: Date }` when the patient submits.
+
+### What to build
+
+Add the three meta-stages around the existing linear card sequence. Welcome card renders `Form.title` and `Form.description` with a Start button. After the last input card, render a review card grouping answers by Section title, each row with its label, current value, and an Edit button that jumps to the source card. From an edit-jump, the path back to review honours normal Continue. Submit button on review fires `patient-form-submit` and transitions to the confirmation card with no Back affordance. Welcome / review / confirmation excluded from progress.
+
+### Acceptance criteria
+
+- [ ] Session starts on the welcome card showing `Form.title` and `Form.description`.
+- [ ] Pressing Start advances to the first input card.
+- [ ] After the last input card, Continue advances to review.
+- [ ] Review groups answers by Section; each row shows label and current value.
+- [ ] Each review row has an Edit button that jumps directly to its source card.
+- [ ] From an edit-jump, Continue returns the patient to review through any intermediate cards' normal navigation.
+- [ ] Submit on review fires a `patient-form-submit` event with `detail: { submittedAt: Date }`.
+- [ ] After submit, renderer shows the confirmation card with no Back affordance.
+- [ ] Welcome / review / confirmation are not counted in the progress fraction.
+- [ ] Unit + integration tests cover: full happy-path flow, edit-jump-and-return, submit event payload, no-back-from-confirmation.
+
+---
+
+## Phase 3: Per-card validation + cross-card deferred to review
+
+**Status: complete.** Tests in `test/e2e/patient-cards-phase3.spec.ts` — 10 / 10 passing.
+
+Test groups:
+
+- **per-card self-validator blocks Continue (3 tests, 3 ✓)** — required validator on current-card field disables Continue; supplying the value re-enables it; clicking a disabled Continue does not advance.
+- **cross-card validator deferred to review (4 tests, 4 ✓)** — cross-card validator does NOT block per-card Continue; failing cross-card validator surfaces on review with edit-jump and blocks Submit; matching values clear the review failure; jump button goes to source card.
+- **self-validator on later card (2 tests, 2 ✓)** — validator attached to a future-card field does not block earlier card's Continue; it activates only when the patient reaches that field's card.
+- **all validators passing (1 test, 1 ✓)** — Submit is enabled on review when nothing fails.
+
+Implementation: dependency-set analysis is done via the existing `BridgedFormValuesContainer.compute(formula)` which returns `{ value, dependencies }`. A validator is classified as cross-card iff any of its `dependencies` resolves to a Field on a later card than the current one. The internal element runs evaluation asynchronously on every change to `formValuesContainer`, `form`, `currentCardIndex`, `stage`, or `language`, using a monotonic `validationVersion` counter to discard stale results.
+
+**User stories**:
+
+- As a patient, I cannot advance past a card with invalid validators on its currently-evaluable validators.
+- As a patient, I see inline validation errors on the offending field while I edit.
+- As a patient, cross-card validation errors (validators depending on later-card answers) are surfaced at review, with edit-jump affordances.
+- As a patient, Submit is blocked while any cross-card validator fails.
+
+### What to build
+
+Classify each card's validators by inspecting the dependency set of the `validation` expression: validators referencing only same-card-or-earlier Fields are currently-evaluable; validators referencing later-card Fields are cross-card. Continue is disabled while any currently-evaluable validator on the current card fails. Reuse existing `validationErrorsProvider` for inline error rendering. On the review card, evaluate all cross-card validators against the complete state; surface failures with edit-jumps to source cards; block Submit until cleared. No changes to the `Validator` interface.
+
+### Acceptance criteria
+
+- [ ] Continue is disabled (visually and behaviourally) while any currently-evaluable validator on the current card fails.
+- [ ] Inline error messages render on the offending field via the existing `validationErrorsProvider`.
+- [ ] Dependency-set analysis correctly classifies validators (test fixture covers same-card, prior-card, and later-card references).
+- [ ] Cross-card validators do not block per-card navigation.
+- [ ] Review surfaces any unresolved cross-card validator failures with edit-jumps.
+- [ ] Submit on review is disabled while any cross-card validator fails.
+- [ ] No new properties added to the `Validator` interface.
+- [ ] Unit tests cover: required-style validator blocks Continue; format validator blocks Continue; cross-card validator doesn't block per-card navigation; review surfaces deferred failures and unblocks once cleared.
+
+---
+
+## Phase 4: Conditional re-evaluation with stay semantics
+
+**Status: complete.** Tests in `test/e2e/patient-cards-phase4.spec.ts` — 10 / 10 passing.
+
+Test groups:
+
+- **Field-level computed hidden (4 tests, 4 ✓)** — conditional initially hidden; Trigger='show' reveals it; flipping back hides; progress fraction recomputes (`1 / 1` → `1 / 2`).
+- **Group-level computed hidden cascades (2 tests, 2 ✓)** — Group's computed hidden propagates to all child fields; Group becomes visible → its fields appear together.
+- **Stay semantics on back-edit (2 tests, 2 ✓)** — hiding a previously-visible card preserves Conditional and AlwaysVisible values in the container; current card index resolves to a sensible adjacent forward card when the visited card vanishes.
+- **Composition with hiddenForPatient (1 test, 1 ✓)** — both static `hiddenForPatient` and computed `hidden` are honoured together (composition by AND of negations: shown iff `!hiddenForPatient && !computedHidden`).
+- **Clinician renderer unchanged (1 test, 1 ✓)** — existing clinician renderer behaviour with computed `hidden` is preserved (no regression).
+
+Implementation: introduced an async `flattenWithVisibility(form, container)` that evaluates each Section / Group / Subform / Field's `computedProperties.hidden` against the container's `compute()` and prunes whole subtrees. The internal element caches the result in `@state cards` and re-runs the async pass on every `formValuesContainer` / `form` change. Position is preserved by remembering the current card's field label across re-flattens; if the field survives, the index follows it; otherwise the index clamps forward.
+
+**User stories**:
+
+- As a form author, my computed `hidden` expressions on Sections / Groups / Fields work in the patient renderer with dynamic re-evaluation, the same way they work in the clinician renderer.
+- As a patient, downstream cards adapt to my earlier answers (e.g. a pregnancy section appears only after I select my gender).
+- As a patient, when I go back and change an answer, my other downstream answers are preserved unchanged.
+- As a patient, the progress fraction recomputes correctly as the card set adapts.
+
+### What to build
+
+Re-run the auto-flatten pass after every Continue and every back-Continue, against the current `FormValuesContainer` state. Compose `hiddenForPatient` and computed `hidden` by AND (a Field is shown iff both are falsy). Map the patient's current position to the new sequence sensibly. Preserve all Field values unconditionally across re-flatten ("stay" semantics — visibility recomputes; data does not). Total card count and progress fraction recompute on every re-flatten.
+
+### Acceptance criteria
+
+- [ ] Answering a Field whose value satisfies a downstream `hidden: <expr>` reveals the previously-hidden element on next Continue.
+- [ ] Changing an answer that previously satisfied a `hidden` condition removes the now-hidden element from the sequence on next Continue.
+- [ ] Total card count and progress fraction recompute on every Continue.
+- [ ] Going back, editing a value, and pressing Continue preserves all downstream Field values.
+- [ ] If the patient's current card disappears due to re-evaluation, position resolves to a sensible adjacent card (forward of the change).
+- [ ] Composition rule `!hiddenForPatient && !computedHidden` is correctly applied.
+- [ ] Clinician renderer's behaviour with computed `hidden` is unchanged.
+- [ ] Unit tests cover: condition-driven appearance; condition-driven disappearance; back-edit preserving unrelated downstream values; progress fraction recomputation; current-card-disappears edge case.
+
+---
+
+## Phase 5: Auto fast-forward resume
+
+**Status: complete.** Tests in `test/e2e/patient-cards-phase5.spec.ts` — 9 / 9 passing.
+
+Test groups:
+
+- **empty container stays on welcome (1 test, 1 ✓)** — first-time use with no values: stage remains `welcome`, no fast-forward triggers.
+- **partial fill jumps to first unanswered card (3 tests, 3 ✓)** — Q1 filled → land on Q2 (idx 1); Q1+Q2 filled → land on Q3 (idx 2); gap in the middle (Q2 missing) → stop at Q2.
+- **fully completed forms land at review (1 test, 1 ✓)** — all fields present and valid → fast-forward goes straight to the review stage.
+- **fast-forward stops at the first invalid card (2 tests, 2 ✓)** — previously-answered field whose validator now fails halts forward progress at that card; passing validators do not halt.
+- **fast-forward composes with conditional hiding (1 test, 1 ✓)** — conditional-hidden cards aren't counted as uncovered; resumes correctly against the visibility-filtered card list.
+- **fast-forward is one-shot (1 test, 1 ✓)** — the `fastForwardChecked` flag is set after the first attempt; navigating back to welcome does NOT re-trigger.
+
+Implementation: `maybeFastForward(cards)` runs once after the initial async reflatten. It checks whether *any* field carries a value; if not, stays on welcome. Otherwise walks the card sequence forward, advancing past cards whose interactive fields all carry values and whose currently-evaluable validators pass; stops at the first uncovered/invalid card, or transitions to `review` if all input cards pass. Pre-fill support added to the harness (`prefill` option) lets tests simulate resume by populating the container before the renderer mounts.
+
+**User stories**:
+
+- As a patient, when I reopen a partially-filled form, I land at the first unanswered/invalid card rather than starting from welcome.
+- As a patient, if I had completed all input cards before closing, I land on the review card.
+
+### What to build
+
+On initial render against a non-empty `FormValuesContainer`, walk the (re-flattened) card sequence virtually, auto-advancing past any card whose interactive Fields have non-empty values and whose currently-evaluable validators pass. Stop at the first card that fails this test (uncovered or invalid), or at the review card if all input cards are complete. No new persistence; no new event or prop surface. Behaviour is derived from data and the validation classifier from phase 3.
+
+### Acceptance criteria
+
+- [ ] Initial render against an empty `FormValuesContainer` shows the welcome card (no fast-forward).
+- [ ] Initial render against a container with first N input cards answered + valid shows card N+1 (or review if N = total input cards).
+- [ ] Fast-forward respects conditional re-evaluation: the sequence is computed against current data before fast-forwarding.
+- [ ] If a previously-answered card now has a failing validator (e.g. due to a conditional change), fast-forward stops at that card.
+- [ ] No new event surface and no new props added.
+- [ ] Unit tests cover: empty container → welcome; half-complete → first unanswered; fully-complete → review; previously-answered-but-now-invalid → stops at that card; resume into a card whose visibility depends on a value entered earlier in the same prior session.
+
+---
+
+## Phase 6: i18n patient-renderer chrome strings
+
+**Status: complete.** Tests in `test/e2e/patient-cards-phase6.spec.ts` — 5 / 5 passing.
+
+Test groups:
+
+- **English defaults (1 test, 1 ✓)** — without a `translationProvider`, English defaults render at every stage.
+- **translationProvider supplies chrome translations (1 test, 1 ✓)** — full French translation set replaces defaults across welcome / input / review / confirmation.
+- **partial translations fall back per-key (1 test, 1 ✓)** — when only some keys are translated, the rest fall back to English on a per-key basis.
+- **progress substitutions (1 test, 1 ✓)** — `{current}` / `{total}` substitutions allow translations to re-order tokens.
+- **existing translate flag continues to work (1 test, 1 ✓)** — field labels and other Form-level content still flow through `translationProvider`; no regression on the existing i18n surface.
+
+Implementation: documented translation keys live in `src/components/icure-form/renderer/patient-cards/translation-keys.ts` as `PatientRendererKeys` (constant map) and `patientRendererDefaults` (English defaults). The `resolveChrome(provider, language, key, substitutions?)` helper returns the translated string or falls back to the English default when the provider returns the key unchanged. Substitution tokens (`{current}`, `{total}`) are applied after translation lookup so locales can re-order them.
+
+**User stories**:
+
+- As a patient, I see Continue / Back / Submit / Start / progress copy / review heading / confirmation heading in my language.
+- As a host app integrator, I provide translations via the existing `translationProvider`.
+
+### What to build
+
+Define a documented translation key set under the `patient-renderer.*` namespace covering every chrome string the renderer emits: `patient-renderer.continue`, `patient-renderer.back`, `patient-renderer.submit`, `patient-renderer.start`, `patient-renderer.progress`, `patient-renderer.review-heading`, `patient-renderer.review-edit`, `patient-renderer.confirmation-heading`, plus any default validation message fallbacks the renderer itself produces. Plumb these through the existing `translationProvider`. When the provider returns the key unchanged, fall back to English defaults. Document the key set in code (constants) and in the CONTEXT or PRD doc surface. Existing `translate` flag on Group/Field continues to behave identically to the clinician renderer.
+
+### Acceptance criteria
+
+- [ ] All renderer-emitted chrome strings flow through `translationProvider(language, 'patient-renderer.<key>')`.
+- [ ] When the provider returns the key unchanged, the renderer falls back to English defaults.
+- [ ] Existing `translate` flag on Group/Field behaves identically to clinician renderer.
+- [ ] No separate i18n machinery introduced (no new providers, no new prop types).
+- [ ] The full key set is documented (in code as exported constants, and in CONTEXT.md or PRD-adjacent doc).
+- [ ] Unit tests cover: provider returns translated string → translated string rendered; provider returns key unchanged → English fallback rendered; per-language switching across all chrome strings.
+
+---
+
+## Phase 7: Field-type coverage rollout + `questionsPerCard=2`
+
+**Status: complete.** Tests in `test/e2e/patient-cards-phase7.spec.ts` — 10 / 10 passing.
+
+Test groups:
+
+- **field-type coverage (1 test, 1 ✓)** — all 11 standard interactive types render in their own card: text, measure, number, date, time, date-time, dropdown, radio, checkbox, token, items-list.
+- **questionsPerCard chunking (3 tests, 3 ✓)** — k=1 default = one card per field; k=2 chunks 5 fields into 3 cards (2+2+1); out-of-range k values clamp to 1..2.
+- **Label fields (2 tests, 2 ✓)** — Label renders inside the card preceding the next interactive field; does not consume a questionsPerCard slot.
+- **Button fields skipped + warned (1 test, 1 ✓)** — `type: action` is excluded from card sequence and a `console.warn` is emitted.
+- **readonly fields (2 tests, 2 ✓)** — `readonly: true` Fields are zero-count toward `questionsPerCard`; still rendered as display-only content in the card.
+- **section / group boundaries (1 test, 1 ✓)** — even with room left in the current chunk, a Section or Group boundary flushes the in-progress card so the section title chrome stays accurate per card.
+
+Implementation: chunking unified into a single `addFieldToCurrent` helper used by both sync and async flatten. `isInteractive` now excludes Label, Button, and readonly Fields. Section / Group boundaries call `commitCard` to force a fresh chunk. `Button (action)` fields trigger `console.warn` at flatten time and are dropped from the sequence. The renderer renders Label as `<icure-form-label>` and Readonly as the regular field component with `.readonly=true`.
+
+**User stories**:
+
+- As a patient, every standard Field type (Text including all ProseMirror schemas, Number, Measure, Date / Time / DateTime, Dropdown, Radio, Checkbox, Token, ItemsList, Label, Button, readonly) renders correctly in patient mode per the PRD coverage table.
+- As a patient on mobile, radio and checkbox controls have touch-friendly tap targets (visual change only).
+- As a patient encountering a Text Field with a `markdown` or `styled` ProseMirror schema, I see a plain text entry without a rich-text toolbar (value still round-trips through the schema).
+- As an integrator, I set `questionsPerCard="2"` and see up to two interactive fields per card; Labels and read-only displays still don't count toward the limit.
+
+### What to build
+
+Iterate the auto-flatten algorithm's chunking step to honour `questionsPerCard` (default `1`, max `2`). Count interactive Fields only — Labels and read-only displays attach to the next emitted card without consuming a slot. Skip Button fields entirely and emit a `console.warn` at parse / render time. For Text Fields with `markdown` or `styled` ProseMirror schemas, render the field with the existing schema but suppress the toolbar in patient mode. Add a touch-friendly visual variant for Radio / Checkbox in the patient theme stub introduced here (full theming polish lands in phase 8). Verify each Field type in the coverage table against a fixture form.
+
+### Acceptance criteria
+
+- [ ] Every Field type in the PRD coverage table renders successfully against a fixture form.
+- [ ] `questionsPerCard="2"` produces cards with ≤2 interactive fields each.
+- [ ] Label Fields render inline within their card and do not count toward `questionsPerCard`.
+- [ ] Read-only Fields render display-only and do not count toward `questionsPerCard` unless they have a non-trivial value.
+- [ ] Button Fields are skipped + `console.warn` is emitted.
+- [ ] Text Fields with `markdown` / `styled` schemas keep the schema but suppress the toolbar.
+- [ ] Radio / Checkbox use a touch-friendly vertical stack (visual change only, no model change).
+- [ ] Unit + integration tests cover: every field type rendered; chunking with k=1 and k=2; Label attached to following card; Button skipped + warned; ProseMirror toolbar suppressed.
+
+---
+
+## Phase 8: Theme + animations + accessibility polish
+
+**Status: complete.** Tests in `test/e2e/patient-cards-phase8.spec.ts` — 13 / 13 passing.
+
+Test groups:
+
+- **ARIA semantics (3 tests, 3 ✓)** — progress bar has `role="progressbar"` with `aria-valuemin/max/now` and an `aria-label`; progress text has `aria-live="polite"`; the validation error banner has `role="alert"`.
+- **focus management (2 tests, 2 ✓)** — Start button receives focus on welcome stage; focus moves to the first interactive field (or Continue) on entering input stage.
+- **touch targets (1 test, 1 ✓)** — primary buttons render with min height/width ≥ 44px (computed bounding rect).
+- **responsive at 360px (2 tests, 2 ✓)** — at viewport 360×640 the card has no horizontal overflow; Start button remains tap-target-sized.
+- **theming hooks (1 test, 1 ✓)** — CSS custom properties (`--patient-cards-accent`, etc.) are exposed on the internal element so host apps can override colours without touching shadow DOM.
+- **keyboard navigation (1 test, 1 ✓)** — Start button can be activated via the Enter key when focused.
+- **axe-core a11y scan (3 tests, 3 ✓)** — welcome / input / review stages have no WCAG 2.1 AA `serious` or `critical` violations, scanned with `@axe-core/playwright`. Embedded field components (`<icure-form-text-field>`, etc.) are filtered out of the patient-cards scope.
+
+Implementation notes:
+
+- Theme colours updated to meet AA contrast (accent `#1d4ed8`, text `#1a1a1a`, muted `#3f3f3f`, error `#8b1111`).
+- Card slide-in animation; submit confirmation checkmark draw-in; both gated by `prefers-reduced-motion: reduce` with opacity-only fallbacks.
+- `firstUpdated` + `updated` lifecycle hooks call a deferred `moveFocusForCurrentStage()` that pierces nested shadow roots to find the most appropriate focus target per stage.
+- Review markup switched from `<dl>` to `<ul role="list">` to avoid axe-core's overly strict dl-direct-children rule and to give edit buttons a descriptive `aria-label="Edit <field label>"`.
+- @axe-core/playwright added as a dev dependency for automated WCAG 2.1 AA scans in CI.
+
+**User stories**:
+
+- As a patient on a 360px-wide phone, the form is comfortably usable.
+- As a patient with `prefers-reduced-motion: reduce`, animations gracefully degrade to opacity-only fades.
+- As a patient using a keyboard, every interaction is reachable via Tab / Shift-Tab / Enter / Space / Arrow keys.
+- As a patient using a screen reader, fields, progress, and validation errors are announced correctly.
+- As a patient, card transitions feel polished and Typeform-class.
+
+### What to build
+
+Ship a new `patient-cards` SCSS theme in `src/components/themes/`, mirroring the existing theme structure and composable via CSS custom properties. Add CSS animations for card slide (forward / back), progress bar fill, field focus rings, button states (active scale, disabled dim), validation error feedback (shake or flash), and submit confirmation (checkmark draw-in). All motion-bearing animations guarded by `prefers-reduced-motion: reduce`, falling back to opacity-only fades. Implement focus management so focus moves to the first interactive field on every card transition. Add `aria-live` region for progress announcements. Associate validation errors to fields via `aria-describedby` + `role="alert"`. Touch targets ≥ 44×44px. Verify mobile breakpoints at 360px. Run axe-core in tests; perform manual screen-reader verification.
+
+### Acceptance criteria
+
+- [ ] `patient-cards` SCSS theme present alongside `default` / `icure-blue` / `kendo`.
+- [ ] Card forward transition: incoming slides in from right, outgoing slides out to left, ~250–350ms ease-out.
+- [ ] Card back transition: reversed direction.
+- [ ] Progress bar width transitions on card change, matching card-transition duration.
+- [ ] Field focus rings transition (~150ms).
+- [ ] Button states: 0.97 scale on active, dimmed opacity on disabled.
+- [ ] Failed-Continue feedback: brief shake or colour flash on offending field.
+- [ ] Submit transition: modest checkmark draw-in on confirmation card.
+- [ ] `prefers-reduced-motion: reduce` honoured throughout (motion replaced with opacity fades).
+- [ ] All interactive elements ≥44×44px touch target.
+- [ ] Layout responsive and usable at 360px viewport width.
+- [ ] Keyboard navigation reaches every interactive control (Tab/Shift-Tab/Enter/Space/Arrow in radio groups).
+- [ ] Focus moves to first interactive field on every card transition.
+- [ ] `aria-live` region announces progress changes.
+- [ ] Validation errors associated to fields via `aria-describedby` + `role="alert"`.
+- [ ] axe-core integration in test suite passes WCAG 2.1 AA checks.
+- [ ] Manual screen-reader walkthrough on iOS Safari + Android Chrome documented.
+- [ ] Bundle size impact for the patient-cards module ≤ 30 KB gzipped (revisit budget after measurement; budget is provisional).

--- a/src/components/common/field-with-options.ts
+++ b/src/components/common/field-with-options.ts
@@ -15,13 +15,34 @@ export const FieldWithOptionsMixin = <T extends Constructor<Field>>(superClass: 
 		@property() optionsProvider: (language: string, terms?: string[]) => Promise<Code[]> = async () => []
 		@state() displayedOptions: Code[] = []
 
+		// Discard stale option-load results if a newer `optionsProvider` (or language) supersedes them.
+		// Without this counter, two rapid changes can race and leave the older promise's options as the
+		// final state.
+		private __optionsLoadVersion = 0
+
+		public updated(changedProperties: PropertyValues) {
+			super.updated?.(changedProperties)
+			// Refresh `displayedOptions` whenever the inputs to optionsProvider change. Element reuse
+			// across cards in patient-cards mode means the same element can be reused for different
+			// fields (different labels/options); loading once in firstUpdated would leave stale options
+			// for every field after the first.
+			if (changedProperties.has('optionsProvider') || changedProperties.has('defaultLanguage') || changedProperties.has('selectedLanguage')) {
+				this.refreshDisplayedOptions()
+			}
+		}
+
 		public firstUpdated(_changedProperties: PropertyValues) {
-			super.firstUpdated(_changedProperties)
-			this.optionsProvider(this.language()).then(async (options) => {
+			super.firstUpdated?.(_changedProperties)
+			this.refreshDisplayedOptions()
+		}
+
+		private refreshDisplayedOptions(): void {
+			const version = ++this.__optionsLoadVersion
+			this.optionsProvider(this.language()).then((options) => {
+				if (version !== this.__optionsLoadVersion) return // newer load supersedes
 				this.displayedOptions = options
 			})
 		}
 	}
-	// Cast return type to the superClass type passed in
 	return FieldWithOptionsMixinClass as Constructor<FieldWithOptionsMixinInterface> & T
 }

--- a/src/components/common/styles/style.scss
+++ b/src/components/common/styles/style.scss
@@ -1295,6 +1295,23 @@ input[type='radio'] {
 					padding-right: 8px;
 				}
 			}
+
+			> .icure-button-group-keyboard-hint {
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				min-width: 18px;
+				height: 18px;
+				padding: 0 5px;
+				margin-left: auto;
+				border-radius: 4px;
+				border: 1px solid #808080;
+				color: #808080;
+				font-size: 11px;
+				font-weight: 600;
+				line-height: 1;
+				flex: 0 0 auto;
+			}
 		}
 	}
 

--- a/src/components/icure-button-group/index.ts
+++ b/src/components/icure-button-group/index.ts
@@ -12,6 +12,7 @@ import { icureFormLogging } from '../../index'
 
 export class IcureButtonGroup extends FieldWithOptionsMixin(Field) {
 	@property() type: 'radio' | 'checkbox' = 'radio'
+	@property({ attribute: false }) keyboardHints?: (string | number)[]
 
 	//override
 	static get styles(): CSSResultGroup[] {
@@ -108,12 +109,15 @@ export class IcureButtonGroup extends FieldWithOptionsMixin(Field) {
 					  `
 					: nothing}
 				<div style="${this.generateStyle()}">
-					${(this.displayedOptions?.length ? this.displayedOptions : [{ id: this.label, label: {} }]).map((x) => {
+					${(this.displayedOptions?.length ? this.displayedOptions : [{ id: this.label, label: {} }]).map((x, idx) => {
 						const text = (x.label ?? {})[this.language()] ?? ''
+						const hint = this.keyboardHints?.[idx]
+						const hintBadge = hint !== undefined && hint !== '' ? html`<span class="icure-button-group-keyboard-hint" aria-hidden="true">${hint}</span>` : nothing
 						if (this.readonly) {
 							return html` <div>
 								<input class="icure-checkbox" disabled type="${this.type}" id="${x.id}" name="${this.label}" value="${text}" .checked="${inputValues?.includes(x.id)}" />
 								<label class="icure-button-group-label" for="${x.id}"><span>${text}</span></label>
+								${hintBadge}
 							</div>`
 						}
 						return html` <div>
@@ -122,6 +126,7 @@ export class IcureButtonGroup extends FieldWithOptionsMixin(Field) {
 								for="${x.id}"
 								><span>${text}</span></label
 							>
+							${hintBadge}
 						</div>`
 					})}
 				</div>

--- a/src/components/icure-form/fields/button-group/checkbox.ts
+++ b/src/components/icure-form/fields/button-group/checkbox.ts
@@ -5,6 +5,7 @@ import { Code } from '../../../model'
 
 export class CheckBox extends Field {
 	@property() optionsProvider: (language: string, searchTerm?: string) => Promise<Code[]> = async () => []
+	@property({ attribute: false }) keyboardHints?: (string | number)[]
 	override renderSync(): TemplateResult[] {
 		const versionedValues = this.valueProvider?.()
 		return (versionedValues && Object.keys(versionedValues).length ? Object.keys(versionedValues) : [undefined]).map((id) => {
@@ -27,6 +28,7 @@ export class CheckBox extends Field {
 					.handleValueChanged=${this.handleSingleValueChanged(id)}
 					.handleMetadataChanged=${this.handleSingleMetadataChanged(id)}
 					.styleOptions=${this.styleOptions}
+					.keyboardHints=${this.keyboardHints}
 				></icure-button-group>
 			`
 		})

--- a/src/components/icure-form/fields/button-group/radio-button.ts
+++ b/src/components/icure-form/fields/button-group/radio-button.ts
@@ -5,6 +5,7 @@ import { Code } from '../../../model'
 
 export class RadioButton extends Field {
 	@property() optionsProvider: (language: string, searchTerm?: string) => Promise<Code[]> = async () => []
+	@property({ attribute: false }) keyboardHints?: (string | number)[]
 	override renderSync(): TemplateResult[] {
 		const versionedValues = this.valueProvider?.()
 		return (versionedValues && Object.keys(versionedValues).length ? Object.keys(versionedValues) : [undefined]).map((id) => {
@@ -27,6 +28,7 @@ export class RadioButton extends Field {
 					.handleValueChanged=${this.handleSingleValueChanged(id)}
 					.handleMetadataChanged=${this.handleSingleMetadataChanged(id)}
 					.styleOptions=${this.styleOptions}
+					.keyboardHints=${this.keyboardHints}
 				></icure-button-group>
 			`
 		})

--- a/src/components/icure-form/index.ts
+++ b/src/components/icure-form/index.ts
@@ -4,6 +4,7 @@ import { property, state } from 'lit/decorators.js'
 
 import { Renderer } from './renderer'
 import { render as renderAsForm } from './renderer/form/form'
+import { render as renderAsPatientCards } from './renderer/patient-cards'
 import { Field, FieldMetadata, FieldValue, Form } from '../model'
 import { FormValuesContainer, Suggestion, Version } from '../../generic'
 
@@ -30,6 +31,7 @@ export class IcureForm extends LitElement {
 	@property() ownersProvider?: (terms: string[], ids?: string[], specialties?: string[]) => Promise<Suggestion[]>
 	@property() optionsProvider?: (language: string, codifications: string[], terms?: string[]) => Promise<Suggestion[]>
 	@property() actionListener?: (event: string, payload: unknown) => void = () => undefined
+	@property({ type: Number }) questionsPerCard = 1
 
 	@state() selectedTab = 0
 
@@ -50,7 +52,8 @@ export class IcureForm extends LitElement {
 			}
 
 			const variant = this.renderer?.split(':')
-			const renderer: Renderer | undefined = variant[0] === 'form' ? renderAsForm : undefined
+			const renderer: Renderer | undefined =
+				variant[0] === 'form' ? renderAsForm : variant[0] === 'patient-cards' ? renderAsPatientCards : undefined
 
 			if (!renderer) {
 				return html`<p>unknown renderer</p>`
@@ -66,7 +69,7 @@ export class IcureForm extends LitElement {
 
 			return renderer(
 				form,
-				{ labelPosition: this.labelPosition, language },
+				{ labelPosition: this.labelPosition, language, questionsPerCard: this.questionsPerCard },
 				formValuesContainer,
 				this.translationProvider ?? (translationTables ? defaultTranslationProvider(translationTables) : undefined),
 				this.revisionsFilter,
@@ -79,7 +82,7 @@ export class IcureForm extends LitElement {
 				sectionWrapper,
 			)
 		},
-		args: () => [this.form, this.formValuesContainer, this.language, this.selectedTab],
+		args: () => [this.form, this.formValuesContainer, this.language, this.selectedTab, this.renderer, this.questionsPerCard],
 	})
 
 	render() {

--- a/src/components/icure-form/renderer/index.ts
+++ b/src/components/icure-form/renderer/index.ts
@@ -6,6 +6,8 @@ export interface RendererProps {
 	language?: string
 	labelPosition?: 'top' | 'left' | 'right' | 'bottom' | 'float'
 	defaultOwner?: string
+	/** Patient-cards renderer only: max interactive fields per card (1 or 2, default 1). */
+	questionsPerCard?: number
 }
 
 export type Renderer = (

--- a/src/components/icure-form/renderer/patient-cards/flatten.ts
+++ b/src/components/icure-form/renderer/patient-cards/flatten.ts
@@ -1,0 +1,235 @@
+import { Field, FieldMetadata, FieldValue, Form, Group, Subform } from '../../../model'
+import { FormValuesContainer } from '../../../../generic'
+
+/**
+ * A single card in the patient-cards renderer's flat sequence.
+ *
+ * `fields` may contain a mix of interactive Fields, Labels, and read-only display Fields. Only
+ * interactive Fields count toward `questionsPerCard`; Labels and read-only displays are visual
+ * content that attach to the surrounding card.
+ */
+export interface Card {
+	sectionTitle: string
+	groupTitle?: string
+	fields: Field[]
+}
+
+/**
+ * Options shared by the sync and async flatten variants.
+ */
+export interface FlattenOptions {
+	/** Maximum interactive Fields per card. Default 1. Capped at 2 by the renderer prop. */
+	questionsPerCard?: number
+}
+
+/**
+ * Counts interactive (patient-input) Fields, excluding Labels and read-only display Fields.
+ */
+function countInteractive(fields: Field[]): number {
+	return fields.filter(isInteractive).length
+}
+
+/**
+ * Sync flatten — hiddenForPatient only, no computed-hidden evaluation. Used by tests and unit
+ * helpers where no FormValuesContainer is available.
+ *
+ * Honours `questionsPerCard` chunking and Label / readonly attachment semantics.
+ */
+export function flatten(form: Form, options: FlattenOptions = {}): Card[] {
+	const ctx = newCtx(options)
+	const visited = new Set<Form>()
+	walkForm(form, ctx, visited)
+	commitCard(ctx)
+	return ctx.out
+}
+
+interface FlattenCtx {
+	out: Card[]
+	current: Card | null
+	k: number
+}
+
+function newCtx(options: FlattenOptions): FlattenCtx {
+	const k = clampK(options.questionsPerCard ?? 1)
+	return { out: [], current: null, k }
+}
+
+function clampK(n: number): number {
+	if (!Number.isFinite(n)) return 1
+	if (n < 1) return 1
+	if (n > 2) return 2
+	return Math.floor(n)
+}
+
+function commitCard(ctx: FlattenCtx): void {
+	if (ctx.current && ctx.current.fields.length > 0) {
+		ctx.out.push(ctx.current)
+	}
+	ctx.current = null
+}
+
+function shouldStartNewCardForContext(ctx: FlattenCtx, sectionTitle: string, groupTitle: string | undefined): boolean {
+	if (!ctx.current) return true
+	return ctx.current.sectionTitle !== sectionTitle || ctx.current.groupTitle !== groupTitle
+}
+
+function addFieldToCurrent(ctx: FlattenCtx, field: Field, sectionTitle: string, groupTitle: string | undefined): void {
+	const interactive = isInteractive(field)
+	const isStandalone = !!field.standalone
+	if (shouldStartNewCardForContext(ctx, sectionTitle, groupTitle)) {
+		commitCard(ctx)
+	}
+	// Standalone fields force a fresh card boundary BEFORE themselves so they never share with a sibling.
+	if (isStandalone && ctx.current && ctx.current.fields.length > 0) {
+		commitCard(ctx)
+	}
+	if (interactive && ctx.current && countInteractive(ctx.current.fields) >= ctx.k) {
+		commitCard(ctx)
+	}
+	if (!ctx.current) {
+		ctx.current = { sectionTitle, groupTitle, fields: [] }
+	}
+	ctx.current.fields.push(field)
+	// And another fresh card boundary AFTER, so the next field (sibling or not) starts on a new card.
+	if (isStandalone) {
+		commitCard(ctx)
+	}
+}
+
+function walkForm(form: Form, ctx: FlattenCtx, visited: Set<Form>): void {
+	if (visited.has(form)) {
+		console.warn('[patient-cards] Cycle detected while recursing through Subform; skipping form', form.form)
+		return
+	}
+	visited.add(form)
+	for (const section of form.sections ?? []) {
+		if (section.hiddenForPatient) continue
+		commitCard(ctx) // Section boundary — new section starts a new card context.
+		for (const child of section.fields ?? []) {
+			walkChild(child, section.section, undefined, ctx, visited)
+		}
+		commitCard(ctx) // Commit any in-progress card at section close.
+	}
+	visited.delete(form)
+}
+
+function walkChild(child: Field | Group | Subform, sectionTitle: string, groupTitle: string | undefined, ctx: FlattenCtx, visited: Set<Form>): void {
+	if ((child as any).hiddenForPatient) return
+	if (isGroup(child)) {
+		const nextGroupTitle = groupTitle ? `${groupTitle} / ${child.group}` : child.group
+		commitCard(ctx) // Group boundary — start fresh group context.
+		for (const inner of child.fields ?? []) {
+			walkChild(inner, sectionTitle, nextGroupTitle, ctx, visited)
+		}
+		commitCard(ctx)
+		return
+	}
+	if (isSubform(child)) {
+		const inner = child.forms ?? {}
+		for (const subform of Object.values(inner)) {
+			walkForm(subform, ctx, visited)
+		}
+		return
+	}
+	// It's a Field.
+	const field = child
+	if (field.type === 'action') {
+		console.warn('[patient-cards] Button (action) field is not supported in patient renderer — skipping', field.field)
+		return
+	}
+	addFieldToCurrent(ctx, field, sectionTitle, groupTitle)
+}
+
+function isGroup(c: Field | Group | Subform): c is Group {
+	return (c as Group).clazz === 'group'
+}
+
+function isSubform(c: Field | Group | Subform): c is Subform {
+	return (c as Subform).clazz === 'subform'
+}
+
+/**
+ * Interactive = "counts toward questionsPerCard". Labels are visual content; readonly Fields are
+ * display-only. Buttons never appear in patient renderer (filtered earlier).
+ */
+export function isInteractive(f: Field): boolean {
+	if (f.type === 'label') return false
+	if (f.type === 'action') return false
+	if (f.readonly) return false
+	return true
+}
+
+/**
+ * Async flatten with computed-`hidden` evaluation. The primary entry point used by the renderer.
+ *
+ * Composition rule: a Field is shown iff `!hiddenForPatient && !computedHidden`.
+ */
+export async function flattenWithVisibility(form: Form, container?: FormValuesContainer<FieldValue, FieldMetadata>, options: FlattenOptions = {}): Promise<Card[]> {
+	const ctx = newCtx(options)
+	const visited = new Set<Form>()
+	await walkFormAsync(form, ctx, visited, container)
+	commitCard(ctx)
+	return ctx.out
+}
+
+async function walkFormAsync(form: Form, ctx: FlattenCtx, visited: Set<Form>, container?: FormValuesContainer<FieldValue, FieldMetadata>): Promise<void> {
+	if (visited.has(form)) {
+		console.warn('[patient-cards] Cycle detected while recursing through Subform; skipping form', form.form)
+		return
+	}
+	visited.add(form)
+	for (const section of form.sections ?? []) {
+		if (section.hiddenForPatient) continue
+		commitCard(ctx)
+		for (const child of section.fields ?? []) {
+			await walkChildAsync(child, section.section, undefined, ctx, visited, container)
+		}
+		commitCard(ctx)
+	}
+	visited.delete(form)
+}
+
+async function walkChildAsync(
+	child: Field | Group | Subform,
+	sectionTitle: string,
+	groupTitle: string | undefined,
+	ctx: FlattenCtx,
+	visited: Set<Form>,
+	container?: FormValuesContainer<FieldValue, FieldMetadata>,
+): Promise<void> {
+	if ((child as any).hiddenForPatient) return
+	if (await isComputedHidden(child, container)) return
+	if (isGroup(child)) {
+		const nextGroupTitle = groupTitle ? `${groupTitle} / ${child.group}` : child.group
+		commitCard(ctx)
+		for (const inner of child.fields ?? []) {
+			await walkChildAsync(inner, sectionTitle, nextGroupTitle, ctx, visited, container)
+		}
+		commitCard(ctx)
+		return
+	}
+	if (isSubform(child)) {
+		const inner = child.forms ?? {}
+		for (const subform of Object.values(inner)) {
+			await walkFormAsync(subform, ctx, visited, container)
+		}
+		return
+	}
+	const field = child
+	if (field.type === 'action') {
+		console.warn('[patient-cards] Button (action) field is not supported in patient renderer — skipping', field.field)
+		return
+	}
+	addFieldToCurrent(ctx, field, sectionTitle, groupTitle)
+}
+
+async function isComputedHidden(node: Field | Group | Subform, container?: FormValuesContainer<FieldValue, FieldMetadata>): Promise<boolean> {
+	const expr = (node as any).computedProperties?.hidden
+	if (!expr || !container) return false
+	try {
+		const result = await (container as any).compute?.(expr)
+		return !!result?.value
+	} catch {
+		return false
+	}
+}

--- a/src/components/icure-form/renderer/patient-cards/index.ts
+++ b/src/components/icure-form/renderer/patient-cards/index.ts
@@ -1,0 +1,48 @@
+import { html } from 'lit'
+import { Renderer } from '../index'
+
+// Side-effect import: register the internal element. The default theme already exposes the user-facing
+// <icure-form> tag; this adds the internal stateful element used by renderer="patient-cards".
+import './register'
+
+/**
+ * Patient-cards renderer.
+ *
+ * Returns a single internal element instance that holds card-index / Continue / Back state.
+ * Provider props are forwarded; the internal element drives everything else.
+ */
+export const render: Renderer = async (
+	form,
+	props,
+	formsValueContainer,
+	translationProvider,
+	revisionsFilter,
+	ownersProvider,
+	optionsProvider,
+	actionListener,
+	languages,
+	readonly,
+	displayMetadata,
+) => {
+	return html`<icure-patient-cards-internal
+		.form=${form}
+		.formValuesContainer=${formsValueContainer}
+		.translationProvider=${translationProvider}
+		.revisionsFilter=${revisionsFilter}
+		.ownersProvider=${ownersProvider}
+		.optionsProvider=${optionsProvider}
+		.actionListener=${actionListener}
+		.languages=${languages}
+		.language=${props.language}
+		.labelPosition=${props.labelPosition}
+		.questionsPerCard=${props.questionsPerCard ?? 1}
+		?readonly=${!!readonly}
+		?displayMetadata=${!!displayMetadata}
+	></icure-patient-cards-internal>`
+}
+
+export { IcurePatientCardsInternal } from './internal'
+export { flatten, flattenWithVisibility } from './flatten'
+export type { Card } from './flatten'
+export { PatientRendererKeys, patientRendererDefaults, resolveChrome } from './translation-keys'
+export type { PatientRendererKey } from './translation-keys'

--- a/src/components/icure-form/renderer/patient-cards/internal.ts
+++ b/src/components/icure-form/renderer/patient-cards/internal.ts
@@ -1,0 +1,940 @@
+import { html, LitElement, nothing, PropertyValues, TemplateResult } from 'lit'
+import { property, state } from 'lit/decorators.js'
+
+import { Field, FieldMetadata, FieldValue, Form, SortOptions } from '../../../model'
+import { FormValuesContainer, Suggestion, Version } from '../../../../generic'
+import { fieldValuesProvider, getValidationErrorProvider, handleMetadataChangedProvider, handleValueChangedProvider } from '../../../../utils/fields-values-provider'
+import { defaultTranslationProvider } from '../../../../utils/languages'
+import { getLabels } from '../../../common/utils'
+import { filterAndSortOptionsFromFieldDefinition, sortSuggestions } from '../../../../utils/code-utils'
+import { currentDate, currentDateTime, currentTime } from '../../../../utils/dates'
+import { parsePrimitive } from '../../../../utils/primitive'
+
+import { Card, flatten, flattenWithVisibility } from './flatten'
+import { resolveChrome } from './translation-keys'
+
+type Stage = 'welcome' | 'input' | 'review' | 'confirmation'
+
+// @ts-ignore
+import baseCss from './patient-cards.scss'
+
+type TranslationProvider = (language: string, text: string) => string
+type RevisionsFilter = (field: Field, id: string, history: Version<FieldMetadata>[]) => string[]
+type OwnersProvider = (terms: string[], ids?: string[], specialties?: string[]) => Promise<Suggestion[]>
+type OptionsProvider = (language: string, codifications: string[], terms?: string[]) => Promise<Suggestion[]>
+type ActionListener = (event: string, payload: unknown) => void
+
+/**
+ * Phase 1 stateful patient-cards element. Owns the current-card index and Continue/Back navigation.
+ *
+ * Re-renders when the form, the container, or the language change (Lit @property reactivity).
+ * `currentCardIndex` survives container updates because the parent <icure-form> reuses the same
+ * element instance across asyncTask re-runs.
+ */
+export class IcurePatientCardsInternal extends LitElement {
+	@property({ attribute: false }) form?: Form
+	@property({ attribute: false }) formValuesContainer?: FormValuesContainer<FieldValue, FieldMetadata>
+	@property({ attribute: false }) translationProvider?: TranslationProvider
+	@property({ attribute: false }) revisionsFilter?: RevisionsFilter
+	@property({ attribute: false }) ownersProvider?: OwnersProvider
+	@property({ attribute: false }) optionsProvider?: OptionsProvider
+	@property({ attribute: false }) actionListener?: ActionListener
+	@property({ attribute: false }) languages?: { [iso: string]: string }
+	@property() language?: string
+	@property({ type: Boolean }) readonly = false
+	@property({ type: Boolean }) displayMetadata = false
+	@property() labelPosition?: 'top' | 'left' | 'right' | 'bottom' | 'float'
+	@property({ type: Number }) questionsPerCard = 1
+
+	@state() private currentCardIndex = 0
+	@state() private stage: Stage = 'welcome'
+	@state() private cameFromReview = false
+
+	// Phase 3 validation state.
+	@state() private evaluating = false
+	@state() private blockingFailures: Array<{ fieldLabel: string; message: string }> = []
+	@state() private reviewFailures: Array<{ fieldLabel: string; cardIndex: number; message: string }> = []
+	private validationVersion = 0
+
+	// Phase 4 conditional-re-evaluation state.
+	@state() private cards: Card[] = []
+	private cardsVersion = 0
+
+	// Phase 5 fast-forward resume state — only attempted once per element instance.
+	private fastForwardChecked = false
+
+	static get styles() {
+		return [baseCss]
+	}
+
+	protected firstUpdated(): void {
+		// Phase 8: ensure focus lands on the appropriate target on initial mount as well.
+		this.scheduleFocus()
+	}
+
+	protected updated(changedProps: PropertyValues): void {
+		// Phase 8: move focus to the most appropriate control after a stage/card transition.
+		if (changedProps.has('stage') || changedProps.has('currentCardIndex')) {
+			this.scheduleFocus()
+		}
+		// Phase 4 / 7: seed cards synchronously when the form or chunking changes.
+		if (changedProps.has('form') || changedProps.has('questionsPerCard')) {
+			this.cards = this.form ? flatten(this.form, { questionsPerCard: this.questionsPerCard }) : []
+		}
+		// Phase 4: re-flatten asynchronously (computed `hidden`) on form/container/chunking changes.
+		if (changedProps.has('formValuesContainer') || changedProps.has('form') || changedProps.has('questionsPerCard')) {
+			const cardsV = ++this.cardsVersion
+			this.reflatten(cardsV)
+		}
+		const watching: Array<keyof IcurePatientCardsInternal> = ['formValuesContainer', 'form', 'currentCardIndex', 'stage', 'language', 'cards' as any]
+		if (watching.some((k) => changedProps.has(k as string))) {
+			const myVersion = ++this.validationVersion
+			if (this.stage === 'input') {
+				this.evaluateCurrentCardValidators(myVersion)
+			} else if (this.stage === 'review') {
+				this.evaluateReviewValidators(myVersion)
+			} else {
+				this.blockingFailures = []
+				this.reviewFailures = []
+				this.evaluating = false
+			}
+		}
+	}
+
+	private async reflatten(version: number): Promise<void> {
+		if (!this.form) return
+		// Remember the field-label currently at the focus position so we can preserve "logical position"
+		// across visibility changes (PRD: "stay" semantics on the navigation index).
+		const prev = this.cards
+		const prevIdx = Math.min(this.currentCardIndex, prev.length - 1)
+		const prevFieldLabel = prev[prevIdx]?.fields[0]?.field
+		let next: Card[]
+		try {
+			next = await flattenWithVisibility(this.form, this.formValuesContainer, { questionsPerCard: this.questionsPerCard })
+		} catch (e) {
+			console.warn('[patient-cards] flattenWithVisibility threw; falling back to sync flatten', e)
+			next = flatten(this.form, { questionsPerCard: this.questionsPerCard })
+		}
+		if (version !== this.cardsVersion) return
+		this.cards = next
+		// Re-align currentCardIndex against the new sequence.
+		if (this.stage === 'input' && prevFieldLabel) {
+			const found = next.findIndex((c) => c.fields.some((f) => f.field === prevFieldLabel))
+			if (found >= 0) {
+				this.currentCardIndex = found
+			} else {
+				// Field went away. Clamp forward — keep the same numeric index where possible, capped.
+				this.currentCardIndex = Math.min(prevIdx, Math.max(0, next.length - 1))
+			}
+		}
+		// Phase 5: after the first successful flatten, attempt to fast-forward into the right stage.
+		if (!this.fastForwardChecked) {
+			this.fastForwardChecked = true
+			await this.maybeFastForward(next)
+		}
+	}
+
+	private fieldHasValue(field: Field): boolean {
+		if (!this.formValuesContainer) return false
+		try {
+			const versioned = fieldValuesProvider(this.formValuesContainer, field, this.revisionsFilter)()
+			const ids = Object.keys(versioned)
+			if (!ids.length) return false
+			const fv = versioned[ids[0]]?.[0]?.value
+			const lang = this.language ?? 'en'
+			const primitive = fv?.content?.[lang] ?? fv?.content?.['*']
+			if (!primitive) return false
+			if (primitive.type === 'string') return primitive.value !== undefined && primitive.value !== ''
+			return true
+		} catch {
+			return false
+		}
+	}
+
+	private async maybeFastForward(cards: Card[]): Promise<void> {
+		// Resume only when there's at least one previously-entered value, the patient hasn't navigated yet,
+		// and a container is available.
+		if (this.stage !== 'welcome') return
+		if (!this.formValuesContainer || !cards.length) return
+		const anyValue = cards.some((c) => c.fields.some((f) => this.fieldHasValue(f)))
+		if (!anyValue) return
+
+		const labelToCard = this.buildLabelToCardIndex(cards)
+		let firstUncovered = -1
+		for (let i = 0; i < cards.length; i++) {
+			const card = cards[i]
+			const allHave = card.fields.every((f) => this.fieldHasValue(f))
+			if (!allHave) {
+				firstUncovered = i
+				break
+			}
+			// Check currently-evaluable validators on this card. Cross-card validators don't block fast-forward.
+			let blocked = false
+			for (const field of card.fields) {
+				for (const validator of field.validators ?? []) {
+					let result: { value?: unknown; dependencies?: string[] } | undefined
+					try {
+						result = await (this.formValuesContainer as any).compute?.(validator.validation)
+					} catch {
+						continue
+					}
+					if (result?.value) continue
+					const deps = result?.dependencies ?? []
+					const isCrossCard = deps.some((d) => {
+						const dc = labelToCard.get(d)
+						return dc !== undefined && dc > i
+					})
+					if (!isCrossCard) {
+						blocked = true
+						break
+					}
+				}
+				if (blocked) break
+			}
+			if (blocked) {
+				firstUncovered = i
+				break
+			}
+		}
+		if (firstUncovered === -1) {
+			// All input cards complete & valid -> go straight to review.
+			this.stage = 'review'
+		} else {
+			this.stage = 'input'
+			this.currentCardIndex = firstUncovered
+		}
+	}
+
+	render(): TemplateResult {
+		if (!this.form) {
+			return html`<p>missing form</p>`
+		}
+		const cards = this.cards
+		if (!cards.length) {
+			return html`<div class="patient-cards patient-cards--empty">
+				<p>This form has no patient-facing questions.</p>
+			</div>`
+		}
+
+		if (this.stage === 'welcome') {
+			return this.renderWelcome(cards.length)
+		}
+		if (this.stage === 'review') {
+			return this.renderReview(cards)
+		}
+		if (this.stage === 'confirmation') {
+			return this.renderConfirmation()
+		}
+		// 'input'
+		const idx = Math.min(this.currentCardIndex, cards.length - 1)
+		return this.renderInput(cards, idx)
+	}
+
+	private renderWelcome(totalCards: number): TemplateResult {
+		const tp = this.translation()
+		const title = this.form?.form ?? ''
+		const description = this.form?.description ?? ''
+		const translatedTitle = tp && this.language ? tp(this.language, title) : title
+		const translatedDescription = tp && this.language && description ? tp(this.language, description) : description
+		const startLabel = resolveChrome(tp, this.language, 'start')
+		return html`
+			<div class="patient-cards patient-cards--stage-welcome" data-stage="welcome" data-total-cards="${totalCards}">
+				<div class="patient-cards__card">
+					<div class="patient-cards__card-body">
+						<h1 class="patient-cards__welcome-title">${translatedTitle}</h1>
+						${translatedDescription ? html`<p class="patient-cards__welcome-description">${translatedDescription}</p>` : nothing}
+					</div>
+				</div>
+				<div class="patient-cards__nav">
+					<span class="patient-cards__back-placeholder"></span>
+					<button class="patient-cards__start" type="button" @click="${this.onStart}">${startLabel}</button>
+				</div>
+			</div>
+		`
+	}
+
+	private renderInput(cards: Card[], idx: number): TemplateResult {
+		const card = cards[idx]
+		const total = cards.length
+		const isLast = idx === total - 1
+		const blocked = this.evaluating || this.blockingFailures.length > 0
+		const tp = this.translation()
+		const continueLabel = resolveChrome(tp, this.language, 'continue')
+		const backLabel = resolveChrome(tp, this.language, 'back')
+		const progressLabel = resolveChrome(tp, this.language, 'progress', { current: idx + 1, total })
+		const localisedSectionTitle = this.localiseChromeText(card.sectionTitle)
+		const localisedGroupTitle = card.groupTitle ? this.localiseGroupTitle(card.groupTitle) : undefined
+		return html`
+			<div
+				class="patient-cards patient-cards--stage-input"
+				data-stage="input"
+				data-current-card-index="${idx}"
+				data-total-cards="${total}"
+				data-blocking-failures="${this.blockingFailures.length}"
+			>
+				<div class="patient-cards__progress" role="progressbar" aria-valuemin="1" aria-valuemax="${total}" aria-valuenow="${idx + 1}" aria-label="${progressLabel}">
+					<div class="patient-cards__progress-bar" style="width: ${((idx + 1) / total) * 100}%"></div>
+					<div class="patient-cards__progress-text" aria-live="polite">${progressLabel}</div>
+				</div>
+				<div class="patient-cards__card" data-card-section="${card.sectionTitle}">
+					<div class="patient-cards__card-header">
+						<div class="patient-cards__section-title">${localisedSectionTitle}</div>
+						${localisedGroupTitle ? html`<div class="patient-cards__group-title">${localisedGroupTitle}</div>` : nothing}
+					</div>
+					<div class="patient-cards__card-body">${card.fields.map((f) => this.renderField(f))}</div>
+				</div>
+				<div class="patient-cards__nav">
+					<button class="patient-cards__back" type="button" @click="${this.onBack}">${backLabel}</button>
+					${this.cameFromReview
+						? html`<button
+								class="patient-cards__continue patient-cards__continue--return-to-review"
+								type="button"
+								?disabled="${blocked}"
+								@click="${this.onContinueReturnToReview}"
+						  >
+								${continueLabel}
+						  </button>`
+						: isLast
+						? html`<button
+								class="patient-cards__continue patient-cards__continue--to-review"
+								type="button"
+								?disabled="${blocked}"
+								@click="${this.onContinueToReview}"
+						  >
+								${continueLabel}
+						  </button>`
+						: html`<button class="patient-cards__continue" type="button" ?disabled="${blocked}" @click="${this.onContinue}">${continueLabel}</button>`}
+				</div>
+			</div>
+		`
+	}
+
+	private renderReview(cards: Card[]): TemplateResult {
+		const tp = this.translation()
+		const language = this.language ?? 'en'
+		// Group cards by their section title to preserve PRD-mandated grouping in review chrome.
+		const groupedBySection: { sectionTitle: string; entries: { card: Card; index: number }[] }[] = []
+		cards.forEach((card, index) => {
+			const last = groupedBySection[groupedBySection.length - 1]
+			if (last && last.sectionTitle === card.sectionTitle) {
+				last.entries.push({ card, index })
+			} else {
+				groupedBySection.push({ sectionTitle: card.sectionTitle, entries: [{ card, index }] })
+			}
+		})
+
+		const submitBlocked = this.evaluating || this.reviewFailures.length > 0
+		const reviewHeading = resolveChrome(tp, this.language, 'reviewHeading')
+		const editLabel = resolveChrome(tp, this.language, 'reviewEdit')
+		const backLabel = resolveChrome(tp, this.language, 'back')
+		const submitLabel = resolveChrome(tp, this.language, 'submit')
+		const reviewErrorsTitle = resolveChrome(tp, this.language, 'reviewErrorsTitle')
+		const reviewEmpty = resolveChrome(tp, this.language, 'reviewEmpty')
+		return html`
+			<div
+				class="patient-cards patient-cards--stage-review"
+				data-stage="review"
+				data-total-cards="${cards.length}"
+				data-review-failures="${this.reviewFailures.length}"
+			>
+				<div class="patient-cards__card">
+					<div class="patient-cards__card-body">
+						<h2 class="patient-cards__review-heading">${reviewHeading}</h2>
+					${this.reviewFailures.length
+						? html`
+								<div class="patient-cards__review-errors" role="alert">
+									<h3 class="patient-cards__review-errors-title">${reviewErrorsTitle}</h3>
+									<ul class="patient-cards__review-errors-list">
+										${this.reviewFailures.map(
+											(f) => html`
+												<li class="patient-cards__review-errors-item" data-error-field-label="${f.fieldLabel}" data-error-card-index="${f.cardIndex}">
+													<span class="patient-cards__review-errors-message">${f.message}</span>
+													<button class="patient-cards__review-errors-jump" type="button" @click="${() => this.onEditJump(f.cardIndex)}">${editLabel}</button>
+												</li>
+											`,
+										)}
+									</ul>
+								</div>
+						  `
+						: nothing}
+					${groupedBySection.map(
+						(g) => html`
+							<div class="patient-cards__review-section">
+								<h3 class="patient-cards__review-section-title">${this.localiseChromeText(g.sectionTitle)}</h3>
+								<ul class="patient-cards__review-list" role="list">
+									${g.entries.map(
+										(e) =>
+											html`${e.card.fields.map((field) => {
+												const value = this.extractDisplayValue(field, language)
+												const labels = getLabels(field)
+												const labelText = labels?.top ?? labels?.left ?? labels?.right ?? labels?.bottom ?? field.field
+												const localisedLabel = field.translate && tp && this.language ? tp(this.language, labelText) : labelText
+												return html`
+													<li class="patient-cards__review-row" data-field-label="${field.field}" data-card-index="${e.index}">
+														<span class="patient-cards__review-label">${localisedLabel}</span>
+														<span class="patient-cards__review-value">${value || html`<span class="patient-cards__review-empty">${reviewEmpty}</span>`}</span>
+														<button class="patient-cards__review-edit" type="button" aria-label="${editLabel} ${localisedLabel}" @click="${() => this.onEditJump(e.index)}">${editLabel}</button>
+													</li>
+												`
+											})}`,
+									)}
+								</ul>
+							</div>
+						`,
+					)}
+					</div>
+				</div>
+				<div class="patient-cards__nav">
+					<button class="patient-cards__back" type="button" @click="${this.onBackFromReview}">${backLabel}</button>
+					<button class="patient-cards__submit" type="button" ?disabled="${submitBlocked}" @click="${this.onSubmit}">${submitLabel}</button>
+				</div>
+			</div>
+		`
+	}
+
+	private renderConfirmation(): TemplateResult {
+		const tp = this.translation()
+		const heading = resolveChrome(tp, this.language, 'confirmationHeading')
+		const body = resolveChrome(tp, this.language, 'confirmationBody')
+		return html`
+			<div class="patient-cards patient-cards--stage-confirmation" data-stage="confirmation">
+				<div class="patient-cards__card patient-cards__card--confirmation">
+					<div class="patient-cards__card-body">
+						<div class="patient-cards__confirmation-check" aria-hidden="true">✓</div>
+						<h2 class="patient-cards__confirmation-heading">${heading}</h2>
+						<p class="patient-cards__confirmation-body">${body}</p>
+					</div>
+				</div>
+			</div>
+		`
+	}
+
+	// ---- Navigation handlers ----
+
+	private onStart = () => {
+		this.stage = 'input'
+		this.currentCardIndex = 0
+	}
+
+	private onContinue = () => {
+		const cards = this.cards
+		if (this.currentCardIndex < cards.length - 1) {
+			this.currentCardIndex = this.currentCardIndex + 1
+		}
+	}
+
+	private onContinueToReview = () => {
+		this.stage = 'review'
+	}
+
+	private onContinueReturnToReview = () => {
+		this.cameFromReview = false
+		this.stage = 'review'
+	}
+
+	private onBack = () => {
+		if (this.currentCardIndex > 0) {
+			this.currentCardIndex = this.currentCardIndex - 1
+		} else {
+			this.stage = 'welcome'
+		}
+	}
+
+	private onBackFromReview = () => {
+		this.stage = 'input'
+		this.currentCardIndex = Math.max(0, this.cards.length - 1)
+	}
+
+	private onEditJump = (cardIndex: number) => {
+		this.stage = 'input'
+		this.currentCardIndex = cardIndex
+		this.cameFromReview = true
+	}
+
+	private onSubmit = () => {
+		this.stage = 'confirmation'
+		this.dispatchEvent(new CustomEvent('patient-form-submit', { detail: { submittedAt: new Date() }, bubbles: true, composed: true }))
+	}
+
+	// ---- Phase 8: focus management ----
+
+	private scheduleFocus(): void {
+		// Defer past Lit's commit and one paint cycle so nested custom elements have a chance to
+		// upgrade and expose their internal contenteditable.
+		requestAnimationFrame(() => requestAnimationFrame(() => this.moveFocusForCurrentStage()))
+	}
+
+	private moveFocusForCurrentStage(): void {
+		const root = this.shadowRoot
+		if (!root) return
+		// Preferred focus targets per stage. Input-stage focus aims at the first interactive form field;
+		// other stages focus their primary action button.
+		const selectorByStage: Record<Stage, string[]> = {
+			welcome: ['.patient-cards__start'],
+			input: [
+				'.patient-cards__field input',
+				'.patient-cards__field textarea',
+				'.patient-cards__field select',
+				'.patient-cards__field [contenteditable="true"]',
+				'.patient-cards__continue',
+			],
+			review: ['.patient-cards__submit'],
+			confirmation: ['.patient-cards__confirmation-heading'],
+		}
+		const candidates = selectorByStage[this.stage] ?? []
+		for (const sel of candidates) {
+			const target = this.queryDeep(root, sel)
+			if (target && typeof (target as HTMLElement).focus === 'function') {
+				try {
+					;(target as HTMLElement).focus({ preventScroll: false })
+				} catch {
+					/* ignore */
+				}
+				return
+			}
+		}
+	}
+
+	/**
+	 * shadow-DOM-aware querySelector that pierces nested shadow roots so we can focus the first
+	 * actual editable element inside a custom field component (e.g. the contenteditable inside
+	 * icure-form-text-field).
+	 */
+	private queryDeep(root: DocumentFragment | ShadowRoot | Element, selector: string): Element | null {
+		const direct = root.querySelector(selector)
+		if (direct) return direct
+		const allElements = root.querySelectorAll('*')
+		for (const el of Array.from(allElements)) {
+			const sr = (el as Element).shadowRoot
+			if (sr) {
+				const found = this.queryDeep(sr, selector)
+				if (found) return found
+			}
+		}
+		return null
+	}
+
+	// ---- Phase 3: validation classification ----
+
+	private buildLabelToCardIndex(cards: Card[]): Map<string, number> {
+		const out = new Map<string, number>()
+		cards.forEach((c, i) => {
+			for (const f of c.fields) {
+				if (!out.has(f.field)) out.set(f.field, i)
+			}
+		})
+		return out
+	}
+
+	private async evaluateCurrentCardValidators(version: number): Promise<void> {
+		if (!this.formValuesContainer || !this.form) return
+		const cards = this.cards
+		if (!cards.length) return
+		const idx = Math.min(this.currentCardIndex, cards.length - 1)
+		const card = cards[idx]
+		const labelToCard = this.buildLabelToCardIndex(cards)
+		this.evaluating = true
+		const blocking: Array<{ fieldLabel: string; message: string }> = []
+		try {
+			for (const field of card.fields) {
+				for (const validator of field.validators ?? []) {
+					let result: { value?: unknown; dependencies?: string[] } | undefined
+					try {
+						result = await (this.formValuesContainer as any).compute?.(validator.validation)
+					} catch (e) {
+						console.warn('[patient-cards] validator threw', validator.validation, e)
+						continue
+					}
+					if (version !== this.validationVersion) return
+					if (result?.value) continue // passes
+					const deps = result?.dependencies ?? []
+					const isCrossCard = deps.some((d) => {
+						const depCard = labelToCard.get(d)
+						return depCard !== undefined && depCard > idx
+					})
+					if (!isCrossCard) {
+						blocking.push({ fieldLabel: field.field, message: validator.message })
+					}
+				}
+			}
+		} finally {
+			if (version === this.validationVersion) {
+				this.evaluating = false
+				this.blockingFailures = blocking
+			}
+		}
+	}
+
+	private async evaluateReviewValidators(version: number): Promise<void> {
+		if (!this.formValuesContainer || !this.form) return
+		const cards = this.cards
+		this.evaluating = true
+		const failures: Array<{ fieldLabel: string; cardIndex: number; message: string }> = []
+		try {
+			for (let i = 0; i < cards.length; i++) {
+				const card = cards[i]
+				for (const field of card.fields) {
+					for (const validator of field.validators ?? []) {
+						let result: { value?: unknown; dependencies?: string[] } | undefined
+						try {
+							result = await (this.formValuesContainer as any).compute?.(validator.validation)
+						} catch (e) {
+							console.warn('[patient-cards] validator threw at review', validator.validation, e)
+							continue
+						}
+						if (version !== this.validationVersion) return
+						if (!result?.value) {
+							failures.push({ fieldLabel: field.field, cardIndex: i, message: validator.message })
+						}
+					}
+				}
+			}
+		} finally {
+			if (version === this.validationVersion) {
+				this.evaluating = false
+				this.reviewFailures = failures
+			}
+		}
+	}
+
+	// ---- Review value extraction ----
+
+	private extractDisplayValue(field: Field, language: string): string {
+		const fvc = this.formValuesContainer
+		if (!fvc) return ''
+		const versioned = fieldValuesProvider(fvc, field, this.revisionsFilter)()
+		// versioned is { [id]: Version<FieldValue>[] } where versions are most recent first.
+		const ids = Object.keys(versioned)
+		if (!ids.length) return ''
+		// Take the first id's most recent version's value.
+		const versions = versioned[ids[0]]
+		if (!versions?.length) return ''
+		const fv = versions[0]?.value
+		const primitive = fv?.content?.[language] ?? fv?.content?.['*']
+		if (!primitive) return ''
+		const parsed = parsePrimitive(primitive, true, language)
+		return parsed === undefined ? '' : String(parsed)
+	}
+
+	// ---- Field rendering ----
+
+	private composedOptionsProvider():
+		| ((language: string, codifications: string[], terms?: string[], sortOptions?: SortOptions) => Promise<Suggestion[]>)
+		| undefined {
+		const optionsProvider = this.optionsProvider
+		const form = this.form
+		if (!optionsProvider) return undefined
+		if (!form?.codifications) {
+			return (language: string, codifications: string[], terms?: string[], sortOptions?: SortOptions) =>
+				optionsProvider(language, codifications, terms).then((codes) => sortSuggestions(codes, language, sortOptions))
+		}
+		return async (language: string, codifications: string[], terms?: string[], sortOptions?: SortOptions): Promise<Suggestion[]> => {
+			const originalOptions = await optionsProvider(language, codifications, terms)
+			return sortSuggestions(
+				originalOptions.concat(
+					form.codifications
+						?.filter((c) => codifications.includes(c.type))
+						?.flatMap((c) =>
+							c.codes
+								.filter((c) => (terms ?? []).map((st) => st.toLowerCase()).every((st) => (c.label?.[language] ?? c.id).toLowerCase().includes(st)))
+								.map((c) => ({ id: c.id, label: c.label ?? { [language]: c.id }, text: c.label?.[language] ?? c.id, terms: terms ?? [] })),
+						) ?? [],
+				),
+				language,
+				sortOptions,
+			)
+		}
+	}
+
+	private translation(): TranslationProvider | undefined {
+		return this.translationProvider ?? (this.form?.translations ? defaultTranslationProvider(this.form.translations) : undefined)
+	}
+
+	/**
+	 * Run a raw author-provided string (Section.section, Group.group, etc.) through the same
+	 * translation pipeline the clinician renderer uses. When no provider/language is available
+	 * or the provider returns the key unchanged, the original string is returned untouched.
+	 */
+	private localiseChromeText(raw: string | undefined): string {
+		if (!raw) return ''
+		const tp = this.translation()
+		if (!tp || !this.language) return raw
+		const translated = tp(this.language, raw)
+		return translated ?? raw
+	}
+
+	/**
+	 * Group titles are emitted as "Outer / Inner" by the flatten step when groups nest. Translate
+	 * each segment individually so the joiner is preserved.
+	 */
+	private localiseGroupTitle(raw: string): string {
+		return raw
+			.split(' / ')
+			.map((part) => this.localiseChromeText(part))
+			.join(' / ')
+	}
+
+	private renderField(fg: Field): TemplateResult | typeof nothing {
+		const fvc = this.formValuesContainer
+		const tp = this.translation()
+		const composedOpts = this.composedOptionsProvider()
+		const readonly = this.readonly || fg.readonly
+		const optsForCodifiable = composedOpts && fg.codifications?.length
+			? (language: string, terms?: string[]) => composedOpts(language, fg.codifications ?? [], terms, fg.sortOptions)
+			: (language: string, terms?: string[]) => filterAndSortOptionsFromFieldDefinition(language, fg, this.translationProvider, terms)
+		const common = {
+			class: 'icure-form-field patient-cards__field',
+			label: fg.field,
+			displayedLabels: getLabels(fg),
+			displayMetadata: this.displayMetadata,
+			defaultLanguage: this.language,
+			translationProvider: tp,
+			validationErrorsProvider: getValidationErrorProvider(fvc, fg),
+			valueProvider: fvc && fieldValuesProvider(fvc, fg, this.revisionsFilter),
+			metadataProvider: fvc && fvc.getMetadata.bind(fvc),
+			handleValueChanged: handleValueChangedProvider(fvc, fg),
+			handleMetadataChanged: handleMetadataChangedProvider(fvc),
+			styleOptions: fg.styleOptions,
+			readonly,
+		}
+		switch (fg.type) {
+			case 'text-field':
+				return html`<icure-form-text-field
+					class="${common.class}"
+					label="${common.label}"
+					value="${fg.value ?? ''}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.multiline="${fg.multiline || false}"
+					.lines=${fg.rowSpan ?? 1}
+					.defaultLanguage="${common.defaultLanguage}"
+					.languages="${this.languages}"
+					.linksProvider=${fg.options?.linksProvider}
+					.suggestionProvider=${fg.options?.suggestionProvider}
+					.ownersProvider=${this.ownersProvider}
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.codeColorProvider=${fg.options?.codeColorProvider}
+					.linkColorProvider=${fg.options?.linkColorProvider}
+					.codeContentProvider=${fg.options?.codeContentProvider}
+					.defaultValueProvider=${fvc?.getDefaultValueProvider?.(fg.field)}
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-text-field>`
+			case 'measure-field':
+				return html`<icure-form-measure-field
+					class="${common.class}"
+					label="${common.label}"
+					value="${fg.value ?? ''}"
+					unit="${fg.unit ?? ''}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.defaultLanguage="${common.defaultLanguage}"
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-measure-field>`
+			case 'number-field':
+				return html`<icure-form-number-field
+					class="${common.class}"
+					label="${common.label}"
+					value="${fg.value ?? ''}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.defaultLanguage="${common.defaultLanguage}"
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-number-field>`
+			case 'token-field':
+				return html`<icure-form-token-field
+					class="${common.class}"
+					label="${common.label}"
+					value="${fg.value ?? ''}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.multiline="${fg.multiline || false}"
+					.lines=${fg.rowSpan ?? 1}
+					.defaultLanguage="${common.defaultLanguage}"
+					.suggestionProvider=${fg.options?.suggestionProvider}
+					.ownersProvider=${this.ownersProvider}
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-token-field>`
+			case 'items-list-field':
+				return html`<icure-form-items-list-field
+					class="${common.class}"
+					label="${common.label}"
+					value="${fg.value ?? ''}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.multiline="${fg.multiline || false}"
+					.lines=${fg.rowSpan ?? 1}
+					.defaultLanguage="${common.defaultLanguage}"
+					.suggestionProvider=${fg.options?.suggestionProvider}
+					.ownersProvider=${this.ownersProvider}
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-items-list-field>`
+			case 'date-picker':
+				return html`<icure-form-date-picker
+					class="${common.class}"
+					label="${common.label}"
+					value="${fg.now ? currentDate() : fg.value ?? ''}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.defaultLanguage="${common.defaultLanguage}"
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-date-picker>`
+			case 'time-picker':
+				return html`<icure-form-time-picker
+					class="${common.class}"
+					label="${common.label}"
+					value="${fg.now ? currentTime() : fg.value ?? ''}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.defaultLanguage="${common.defaultLanguage}"
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-time-picker>`
+			case 'date-time-picker':
+				return html`<icure-form-date-time-picker
+					class="${common.class}"
+					label="${common.label}"
+					value="${fg.now ? currentDateTime() : fg.value ?? ''}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.defaultLanguage="${common.defaultLanguage}"
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-date-time-picker>`
+			case 'dropdown-field':
+			case 'dropdown' as any:
+				return html`<icure-form-dropdown-field
+					class="${common.class}"
+					.label=${common.label}
+					.displayedLabels=${common.displayedLabels}
+					.defaultLanguage="${common.defaultLanguage}"
+					.translate="${fg.translate}"
+					.sortOptions="${fg.sortOptions}"
+					value="${fg.value ?? ''}"
+					.codifications="${fg.codifications}"
+					.optionsProvider="${optsForCodifiable}"
+					.ownersProvider=${this.ownersProvider}
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-dropdown-field>`
+			case 'radio-button':
+				return html`<icure-form-radio-button
+					class="${common.class}"
+					.label="${common.label}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.defaultLanguage="${common.defaultLanguage}"
+					.translate="${fg.translate}"
+					.sortOptions="${fg.sortOptions}"
+					.codifications="${fg.codifications}"
+					.optionsProvider="${optsForCodifiable}"
+					.ownersProvider=${this.ownersProvider}
+					.translationProvider=${common.translationProvider}
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider=${common.metadataProvider}
+					.handleValueChanged=${common.handleValueChanged}
+					.handleMetadataChanged=${common.handleMetadataChanged}
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-radio-button>`
+			case 'checkbox':
+				return html`<icure-form-checkbox
+					class="${common.class}"
+					.label="${common.label}"
+					.displayedLabels="${common.displayedLabels}"
+					.displayMetadata="${common.displayMetadata}"
+					.defaultLanguage="${common.defaultLanguage}"
+					.translate="${fg.translate}"
+					.sortOptions="${fg.sortOptions}"
+					value="${fg.value ?? ''}"
+					.codifications="${fg.codifications}"
+					.optionsProvider="${optsForCodifiable}"
+					.ownersProvider="${this.ownersProvider}"
+					.translationProvider="${common.translationProvider}"
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.valueProvider="${common.valueProvider}"
+					.metadataProvider="${common.metadataProvider}"
+					.handleValueChanged="${common.handleValueChanged}"
+					.handleMetadataChanged="${common.handleMetadataChanged}"
+					.styleOptions="${common.styleOptions}"
+					.readonly="${common.readonly}"
+				></icure-form-checkbox>`
+			case 'label':
+				return html`<icure-form-label
+					class="${common.class} patient-cards__label-field"
+					.defaultLanguage="${common.defaultLanguage}"
+					labelPosition=${this.labelPosition}
+					label="${fg.shortLabel ?? fg.field}"
+					.translationProvider="${common.translationProvider}"
+					.validationErrorsProvider="${common.validationErrorsProvider}"
+					.styleOptions="${common.styleOptions}"
+				></icure-form-label>`
+			default:
+				// Defensive: any future field type that isn't explicitly handled is silently skipped.
+				// Button (type=action) is filtered before this point by the flatten step.
+				return nothing
+		}
+	}
+}
+
+// Expose a helper for tests / hosts to peek at the flatten result without instantiating the element.
+export { flatten } from './flatten'

--- a/src/components/icure-form/renderer/patient-cards/internal.ts
+++ b/src/components/icure-form/renderer/patient-cards/internal.ts
@@ -15,6 +15,8 @@ import { resolveChrome } from './translation-keys'
 
 type Stage = 'welcome' | 'input' | 'review' | 'confirmation'
 
+const PATIENT_CARDS_DIGIT_HINTS: ReadonlyArray<number> = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
 // @ts-ignore
 import baseCss from './patient-cards.scss'
 
@@ -65,6 +67,19 @@ export class IcurePatientCardsInternal extends LitElement {
 
 	static get styles() {
 		return [baseCss]
+	}
+
+	override connectedCallback(): void {
+		super.connectedCallback()
+		// Document-level capture: catches keystrokes even when focus is outside this element's
+		// subtree (e.g. after the patient clicked on the page background). Capture phase ensures we
+		// intercept Enter before inner editors (ProseMirror) consume it.
+		document.addEventListener('keydown', this.onKeyDown, { capture: true })
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback()
+		document.removeEventListener('keydown', this.onKeyDown, { capture: true })
 	}
 
 	protected firstUpdated(): void {
@@ -247,7 +262,10 @@ export class IcurePatientCardsInternal extends LitElement {
 				</div>
 				<div class="patient-cards__nav">
 					<span class="patient-cards__back-placeholder"></span>
-					<button class="patient-cards__start" type="button" @click="${this.onStart}">${startLabel}</button>
+					<button class="patient-cards__start" type="button" @click="${this.onStart}">
+						<span class="patient-cards__action-label">${startLabel}</span>
+						<span class="patient-cards__key-hint" aria-hidden="true">↵</span>
+					</button>
 				</div>
 			</div>
 		`
@@ -265,13 +283,7 @@ export class IcurePatientCardsInternal extends LitElement {
 		const localisedSectionTitle = this.localiseChromeText(card.sectionTitle)
 		const localisedGroupTitle = card.groupTitle ? this.localiseGroupTitle(card.groupTitle) : undefined
 		return html`
-			<div
-				class="patient-cards patient-cards--stage-input"
-				data-stage="input"
-				data-current-card-index="${idx}"
-				data-total-cards="${total}"
-				data-blocking-failures="${this.blockingFailures.length}"
-			>
+			<div class="patient-cards patient-cards--stage-input" data-stage="input" data-current-card-index="${idx}" data-total-cards="${total}" data-blocking-failures="${this.blockingFailures.length}">
 				<div class="patient-cards__progress" role="progressbar" aria-valuemin="1" aria-valuemax="${total}" aria-valuenow="${idx + 1}" aria-label="${progressLabel}">
 					<div class="patient-cards__progress-bar" style="width: ${((idx + 1) / total) * 100}%"></div>
 					<div class="patient-cards__progress-text" aria-live="polite">${progressLabel}</div>
@@ -286,24 +298,19 @@ export class IcurePatientCardsInternal extends LitElement {
 				<div class="patient-cards__nav">
 					<button class="patient-cards__back" type="button" @click="${this.onBack}">${backLabel}</button>
 					${this.cameFromReview
-						? html`<button
-								class="patient-cards__continue patient-cards__continue--return-to-review"
-								type="button"
-								?disabled="${blocked}"
-								@click="${this.onContinueReturnToReview}"
-						  >
-								${continueLabel}
+						? html`<button class="patient-cards__continue patient-cards__continue--return-to-review" type="button" ?disabled="${blocked}" @click="${this.onContinueReturnToReview}">
+								<span class="patient-cards__action-label">${continueLabel}</span>
+								<span class="patient-cards__key-hint" aria-hidden="true">↵</span>
 						  </button>`
 						: isLast
-						? html`<button
-								class="patient-cards__continue patient-cards__continue--to-review"
-								type="button"
-								?disabled="${blocked}"
-								@click="${this.onContinueToReview}"
-						  >
-								${continueLabel}
+						? html`<button class="patient-cards__continue patient-cards__continue--to-review" type="button" ?disabled="${blocked}" @click="${this.onContinueToReview}">
+								<span class="patient-cards__action-label">${continueLabel}</span>
+								<span class="patient-cards__key-hint" aria-hidden="true">↵</span>
 						  </button>`
-						: html`<button class="patient-cards__continue" type="button" ?disabled="${blocked}" @click="${this.onContinue}">${continueLabel}</button>`}
+						: html`<button class="patient-cards__continue" type="button" ?disabled="${blocked}" @click="${this.onContinue}">
+								<span class="patient-cards__action-label">${continueLabel}</span>
+								<span class="patient-cards__key-hint" aria-hidden="true">↵</span>
+						  </button>`}
 				</div>
 			</div>
 		`
@@ -331,62 +338,59 @@ export class IcurePatientCardsInternal extends LitElement {
 		const reviewErrorsTitle = resolveChrome(tp, this.language, 'reviewErrorsTitle')
 		const reviewEmpty = resolveChrome(tp, this.language, 'reviewEmpty')
 		return html`
-			<div
-				class="patient-cards patient-cards--stage-review"
-				data-stage="review"
-				data-total-cards="${cards.length}"
-				data-review-failures="${this.reviewFailures.length}"
-			>
+			<div class="patient-cards patient-cards--stage-review" data-stage="review" data-total-cards="${cards.length}" data-review-failures="${this.reviewFailures.length}">
 				<div class="patient-cards__card">
 					<div class="patient-cards__card-body">
 						<h2 class="patient-cards__review-heading">${reviewHeading}</h2>
-					${this.reviewFailures.length
-						? html`
-								<div class="patient-cards__review-errors" role="alert">
-									<h3 class="patient-cards__review-errors-title">${reviewErrorsTitle}</h3>
-									<ul class="patient-cards__review-errors-list">
-										${this.reviewFailures.map(
-											(f) => html`
-												<li class="patient-cards__review-errors-item" data-error-field-label="${f.fieldLabel}" data-error-card-index="${f.cardIndex}">
-													<span class="patient-cards__review-errors-message">${f.message}</span>
-													<button class="patient-cards__review-errors-jump" type="button" @click="${() => this.onEditJump(f.cardIndex)}">${editLabel}</button>
-												</li>
-											`,
+						${this.reviewFailures.length
+							? html`
+									<div class="patient-cards__review-errors" role="alert">
+										<h3 class="patient-cards__review-errors-title">${reviewErrorsTitle}</h3>
+										<ul class="patient-cards__review-errors-list">
+											${this.reviewFailures.map(
+												(f) => html`
+													<li class="patient-cards__review-errors-item" data-error-field-label="${f.fieldLabel}" data-error-card-index="${f.cardIndex}">
+														<span class="patient-cards__review-errors-message">${f.message}</span>
+														<button class="patient-cards__review-errors-jump" type="button" @click="${() => this.onEditJump(f.cardIndex)}">${editLabel}</button>
+													</li>
+												`,
+											)}
+										</ul>
+									</div>
+							  `
+							: nothing}
+						${groupedBySection.map(
+							(g) => html`
+								<div class="patient-cards__review-section">
+									<h3 class="patient-cards__review-section-title">${this.localiseChromeText(g.sectionTitle)}</h3>
+									<ul class="patient-cards__review-list" role="list">
+										${g.entries.map(
+											(e) =>
+												html`${e.card.fields.map((field) => {
+													const value = this.extractDisplayValue(field, language)
+													const labelText = field.shortLabel ?? field.field
+													const localisedLabel = field.translate && tp && this.language ? tp(this.language, labelText) : labelText
+													return html`
+														<li class="patient-cards__review-row" data-field-label="${field.field}" data-card-index="${e.index}">
+															<span class="patient-cards__review-label" title="${localisedLabel}">${localisedLabel}</span>
+															<span class="patient-cards__review-value">${value || html`<span class="patient-cards__review-empty">${reviewEmpty}</span>`}</span>
+															<button class="patient-cards__review-edit" type="button" aria-label="${editLabel} ${localisedLabel}" @click="${() => this.onEditJump(e.index)}">${editLabel}</button>
+														</li>
+													`
+												})}`,
 										)}
 									</ul>
 								</div>
-						  `
-						: nothing}
-					${groupedBySection.map(
-						(g) => html`
-							<div class="patient-cards__review-section">
-								<h3 class="patient-cards__review-section-title">${this.localiseChromeText(g.sectionTitle)}</h3>
-								<ul class="patient-cards__review-list" role="list">
-									${g.entries.map(
-										(e) =>
-											html`${e.card.fields.map((field) => {
-												const value = this.extractDisplayValue(field, language)
-												const labels = getLabels(field)
-												const labelText = labels?.top ?? labels?.left ?? labels?.right ?? labels?.bottom ?? field.field
-												const localisedLabel = field.translate && tp && this.language ? tp(this.language, labelText) : labelText
-												return html`
-													<li class="patient-cards__review-row" data-field-label="${field.field}" data-card-index="${e.index}">
-														<span class="patient-cards__review-label">${localisedLabel}</span>
-														<span class="patient-cards__review-value">${value || html`<span class="patient-cards__review-empty">${reviewEmpty}</span>`}</span>
-														<button class="patient-cards__review-edit" type="button" aria-label="${editLabel} ${localisedLabel}" @click="${() => this.onEditJump(e.index)}">${editLabel}</button>
-													</li>
-												`
-											})}`,
-									)}
-								</ul>
-							</div>
-						`,
-					)}
+							`,
+						)}
 					</div>
 				</div>
 				<div class="patient-cards__nav">
 					<button class="patient-cards__back" type="button" @click="${this.onBackFromReview}">${backLabel}</button>
-					<button class="patient-cards__submit" type="button" ?disabled="${submitBlocked}" @click="${this.onSubmit}">${submitLabel}</button>
+					<button class="patient-cards__submit" type="button" ?disabled="${submitBlocked}" @click="${this.onSubmit}">
+						<span class="patient-cards__action-label">${submitLabel}</span>
+						<span class="patient-cards__key-hint" aria-hidden="true">↵</span>
+					</button>
 				</div>
 			</div>
 		`
@@ -456,6 +460,111 @@ export class IcurePatientCardsInternal extends LitElement {
 		this.dispatchEvent(new CustomEvent('patient-form-submit', { detail: { submittedAt: new Date() }, bubbles: true, composed: true }))
 	}
 
+	// ---- Keyboard navigation ----
+
+	private onKeyDown = (e: KeyboardEvent): void => {
+		// Capturing-phase listener: runs before any inner editor sees the keystroke.
+		if (e.altKey || e.metaKey || e.ctrlKey) return
+		const path = e.composedPath()
+		if (!this.isOurKeyboardContext(path)) return
+		const editing = this.classifyEditingTarget(path)
+		if (e.key === 'Enter') {
+			// Let Enter through for multi-line editors and for native button activation.
+			if (editing.multiline || editing.isButton) return
+			const advanced = this.advanceForCurrentStage()
+			if (advanced) {
+				e.preventDefault()
+				e.stopImmediatePropagation()
+			}
+			return
+		}
+		if (/^[1-9]$/.test(e.key) && !editing.anyText) {
+			const handled = this.activateOptionByDigit(parseInt(e.key, 10))
+			if (handled) {
+				e.preventDefault()
+				e.stopImmediatePropagation()
+			}
+		}
+	}
+
+	/**
+	 * Are we the patient-cards instance that should respond to this keystroke? True if the event
+	 * originates within our DOM subtree, or if focus has dropped to the document body (typical when
+	 * the patient clicks the form's background).
+	 */
+	private isOurKeyboardContext(path: EventTarget[]): boolean {
+		if (path.includes(this)) return true
+		const active = document.activeElement
+		return !active || active === document.body || active === document.documentElement
+	}
+
+	private classifyEditingTarget(path: EventTarget[]): { anyText: boolean; multiline: boolean; isButton: boolean } {
+		const target = path[0] as Element | undefined
+		if (!target) return { anyText: false, multiline: false, isButton: false }
+		const tag = (target as Element).tagName
+		if (tag === 'BUTTON') return { anyText: false, multiline: false, isButton: true }
+		if (tag === 'TEXTAREA') return { anyText: true, multiline: true, isButton: false }
+		if (tag === 'INPUT') {
+			const type = (target as HTMLInputElement).type
+			const textTypes = ['text', 'email', 'tel', 'url', 'number', 'search', 'password', 'date', 'time', 'datetime-local']
+			if (textTypes.includes(type)) return { anyText: true, multiline: false, isButton: false }
+			return { anyText: false, multiline: false, isButton: false }
+		}
+		if ((target as HTMLElement).isContentEditable) {
+			const textField = path.find((n) => (n as Element).tagName?.toLowerCase() === 'icure-form-text-field') as HTMLElement | undefined
+			const ml = textField ? !!(textField as any).multiline : false
+			return { anyText: true, multiline: ml, isButton: false }
+		}
+		return { anyText: false, multiline: false, isButton: false }
+	}
+
+	private advanceForCurrentStage(): boolean {
+		switch (this.stage) {
+			case 'welcome':
+				this.onStart()
+				return true
+			case 'input': {
+				if (this.evaluating || this.blockingFailures.length > 0) return false
+				const cards = this.cards
+				if (!cards.length) return false
+				const isLast = this.currentCardIndex === cards.length - 1
+				if (this.cameFromReview) this.onContinueReturnToReview()
+				else if (isLast) this.onContinueToReview()
+				else this.onContinue()
+				return true
+			}
+			case 'review':
+				if (this.evaluating || this.reviewFailures.length > 0) return false
+				this.onSubmit()
+				return true
+			default:
+				return false
+		}
+	}
+
+	private activateOptionByDigit(digit: number): boolean {
+		if (this.stage !== 'input') return false
+		const cards = this.cards
+		if (!cards.length) return false
+		const idx = Math.min(this.currentCardIndex, cards.length - 1)
+		const card = cards[idx]
+		const field = card.fields.find((f) => f.type === 'radio-button' || f.type === 'checkbox')
+		if (!field) return false
+		const root = this.shadowRoot
+		if (!root) return false
+		const fieldTag = field.type === 'radio-button' ? 'icure-form-radio-button' : 'icure-form-checkbox'
+		const fieldEl = root.querySelector(fieldTag) as HTMLElement | null
+		if (!fieldEl) return false
+		const buttonGroup = this.queryDeep(fieldEl, 'icure-button-group') as HTMLElement | null
+		const buttonGroupShadow = buttonGroup?.shadowRoot
+		if (!buttonGroupShadow) return false
+		const inputs = Array.from(buttonGroupShadow.querySelectorAll('input.icure-checkbox')) as HTMLInputElement[]
+		const input = inputs[digit - 1]
+		if (!input || input.disabled) return false
+		input.click()
+		return true
+	}
+
 	// ---- Phase 8: focus management ----
 
 	private scheduleFocus(): void {
@@ -471,13 +580,7 @@ export class IcurePatientCardsInternal extends LitElement {
 		// other stages focus their primary action button.
 		const selectorByStage: Record<Stage, string[]> = {
 			welcome: ['.patient-cards__start'],
-			input: [
-				'.patient-cards__field input',
-				'.patient-cards__field textarea',
-				'.patient-cards__field select',
-				'.patient-cards__field [contenteditable="true"]',
-				'.patient-cards__continue',
-			],
+			input: ['.patient-cards__field input', '.patient-cards__field textarea', '.patient-cards__field select', '.patient-cards__field [contenteditable="true"]', '.patient-cards__continue'],
 			review: ['.patient-cards__submit'],
 			confirmation: ['.patient-cards__confirmation-heading'],
 		}
@@ -504,7 +607,7 @@ export class IcurePatientCardsInternal extends LitElement {
 		const direct = root.querySelector(selector)
 		if (direct) return direct
 		const allElements = root.querySelectorAll('*')
-		for (const el of Array.from(allElements)) {
+		for (const el of [root, ...Array.from(allElements)]) {
 			const sr = (el as Element).shadowRoot
 			if (sr) {
 				const found = this.queryDeep(sr, selector)
@@ -612,15 +715,27 @@ export class IcurePatientCardsInternal extends LitElement {
 		const fv = versions[0]?.value
 		const primitive = fv?.content?.[language] ?? fv?.content?.['*']
 		if (!primitive) return ''
+		// Radio/checkbox values arrive as a compound primitive whose entries are `true` per selected
+		// option id. `parsePrimitive` on those just yields ["true", ...]; the human-readable choice
+		// labels live on `fv.codes` (populated by IcureButtonGroup.checkboxChange).
+		if (primitive.type === 'compound') {
+			const codes = fv?.codes ?? []
+			if (!codes.length) return ''
+			const tp = this.translation()
+			const translate = field.translate !== false
+			const labels = codes.map((c) => {
+				const raw = c.label?.[language] ?? c.label?.['*'] ?? c.id
+				return translate && tp && this.language ? tp(this.language, raw) : raw
+			})
+			return labels.join(', ')
+		}
 		const parsed = parsePrimitive(primitive, true, language)
 		return parsed === undefined ? '' : String(parsed)
 	}
 
 	// ---- Field rendering ----
 
-	private composedOptionsProvider():
-		| ((language: string, codifications: string[], terms?: string[], sortOptions?: SortOptions) => Promise<Suggestion[]>)
-		| undefined {
+	private composedOptionsProvider(): ((language: string, codifications: string[], terms?: string[], sortOptions?: SortOptions) => Promise<Suggestion[]>) | undefined {
 		const optionsProvider = this.optionsProvider
 		const form = this.form
 		if (!optionsProvider) return undefined
@@ -679,9 +794,10 @@ export class IcurePatientCardsInternal extends LitElement {
 		const tp = this.translation()
 		const composedOpts = this.composedOptionsProvider()
 		const readonly = this.readonly || fg.readonly
-		const optsForCodifiable = composedOpts && fg.codifications?.length
-			? (language: string, terms?: string[]) => composedOpts(language, fg.codifications ?? [], terms, fg.sortOptions)
-			: (language: string, terms?: string[]) => filterAndSortOptionsFromFieldDefinition(language, fg, this.translationProvider, terms)
+		const optsForCodifiable =
+			composedOpts && fg.codifications?.length
+				? (language: string, terms?: string[]) => composedOpts(language, fg.codifications ?? [], terms, fg.sortOptions)
+				: (language: string, terms?: string[]) => filterAndSortOptionsFromFieldDefinition(language, fg, this.translationProvider, terms)
 		const common = {
 			class: 'icure-form-field patient-cards__field',
 			label: fg.field,
@@ -895,6 +1011,7 @@ export class IcurePatientCardsInternal extends LitElement {
 					.handleMetadataChanged=${common.handleMetadataChanged}
 					.styleOptions="${common.styleOptions}"
 					.readonly="${common.readonly}"
+					.keyboardHints=${PATIENT_CARDS_DIGIT_HINTS}
 				></icure-form-radio-button>`
 			case 'checkbox':
 				return html`<icure-form-checkbox
@@ -917,6 +1034,7 @@ export class IcurePatientCardsInternal extends LitElement {
 					.handleMetadataChanged="${common.handleMetadataChanged}"
 					.styleOptions="${common.styleOptions}"
 					.readonly="${common.readonly}"
+					.keyboardHints=${PATIENT_CARDS_DIGIT_HINTS}
 				></icure-form-checkbox>`
 			case 'label':
 				return html`<icure-form-label

--- a/src/components/icure-form/renderer/patient-cards/patient-cards.scss
+++ b/src/components/icure-form/renderer/patient-cards/patient-cards.scss
@@ -159,6 +159,35 @@
 	color: var(--patient-cards-accent-text);
 }
 
+.patient-cards__start,
+.patient-cards__continue,
+.patient-cards__submit {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+}
+
+.patient-cards__key-hint {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 5px;
+	border-radius: 4px;
+	border: 1px solid currentColor;
+	font-size: 11px;
+	line-height: 1;
+	opacity: 0.85;
+}
+
+.patient-cards__start[disabled] .patient-cards__key-hint,
+.patient-cards__continue[disabled] .patient-cards__key-hint,
+.patient-cards__submit[disabled] .patient-cards__key-hint {
+	opacity: 0.5;
+}
+
 .patient-cards__continue:hover:not(:disabled),
 .patient-cards__submit:hover:not(:disabled),
 .patient-cards__start:hover:not(:disabled) {
@@ -250,6 +279,10 @@
 .patient-cards__review-label {
 	font-weight: 500;
 	color: #333;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 .patient-cards__review-value {

--- a/src/components/icure-form/renderer/patient-cards/patient-cards.scss
+++ b/src/components/icure-form/renderer/patient-cards/patient-cards.scss
@@ -1,0 +1,385 @@
+:host {
+	display: block;
+	box-sizing: border-box;
+
+	/* Themeable surface — host apps override via CSS custom properties.
+	 * Defaults are chosen to meet WCAG 2.1 AA contrast (≥4.5:1 for normal text). */
+	--patient-cards-accent: #1d4ed8;
+	--patient-cards-accent-text: #ffffff;
+	--patient-cards-bg: #ffffff;
+	--patient-cards-text: #1a1a1a;
+	--patient-cards-muted: #3f3f3f;
+	--patient-cards-border: #c4c4c4;
+	--patient-cards-error: #8b1111;
+	--patient-cards-error-bg: #fff4f4;
+	--patient-cards-progress-bg: #d4d4d4;
+	--patient-cards-card-radius: 8px;
+	--patient-cards-card-padding: 24px;
+	--patient-cards-card-height: 800px;
+	--patient-cards-max-width: 600px;
+	--patient-cards-transition: 280ms;
+}
+
+.patient-cards {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 16px;
+	max-width: var(--patient-cards-max-width);
+	margin: 0 auto;
+	font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+	color: var(--patient-cards-text);
+}
+
+@media (max-width: 480px) {
+	.patient-cards {
+		padding: 12px;
+		gap: 12px;
+	}
+}
+
+.patient-cards--empty {
+	text-align: center;
+	color: #666;
+}
+
+.patient-cards__progress {
+	position: relative;
+	height: 8px;
+	background: var(--patient-cards-progress-bg);
+	border-radius: 4px;
+	overflow: hidden;
+}
+
+.patient-cards__progress-bar {
+	height: 100%;
+	background: var(--patient-cards-accent);
+	transition: width var(--patient-cards-transition) ease-out;
+}
+
+.patient-cards__progress-text {
+	position: absolute;
+	right: 0;
+	top: 12px;
+	font-size: 12px;
+	color: #525252;
+}
+
+.patient-cards__card {
+	background: var(--patient-cards-bg);
+	border: 1px solid var(--patient-cards-border);
+	border-radius: var(--patient-cards-card-radius);
+	padding: var(--patient-cards-card-padding);
+	height: var(--patient-cards-card-height);
+	max-height: calc(100vh - 210px);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	animation: patient-cards__card-slide-in var(--patient-cards-transition) ease-out;
+}
+
+.patient-cards__card-header {
+	flex: 0 0 auto;
+	margin-bottom: 16px;
+}
+
+.patient-cards__card-body {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+@keyframes patient-cards__card-slide-in {
+	from {
+		opacity: 0;
+		transform: translateX(24px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}
+
+.patient-cards__section-title {
+	font-size: 12px;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: #595959;
+}
+
+.patient-cards__group-title {
+	font-size: 13px;
+	color: #444;
+	margin-top: 2px;
+}
+
+.patient-cards__field {
+	display: block;
+}
+
+.patient-cards__nav {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 12px;
+}
+
+.patient-cards__back,
+.patient-cards__continue,
+.patient-cards__submit {
+	min-height: 44px;
+	min-width: 96px;
+	padding: 10px 18px;
+	border-radius: 6px;
+	border: 1px solid transparent;
+	font-size: 15px;
+	cursor: pointer;
+}
+
+.patient-cards__back {
+	background: #f5f5f5;
+	color: #333;
+	border-color: #ddd;
+}
+
+.patient-cards__back:hover {
+	background: #ececec;
+}
+
+.patient-cards__back-placeholder {
+	min-width: 96px;
+}
+
+.patient-cards__continue,
+.patient-cards__submit {
+	background: var(--patient-cards-accent);
+	color: var(--patient-cards-accent-text);
+}
+
+.patient-cards__continue:hover:not(:disabled),
+.patient-cards__submit:hover:not(:disabled),
+.patient-cards__start:hover:not(:disabled) {
+	filter: brightness(0.95);
+}
+
+.patient-cards__continue:active:not(:disabled),
+.patient-cards__submit:active:not(:disabled),
+.patient-cards__start:active:not(:disabled) {
+	transform: scale(0.97);
+}
+
+.patient-cards__back:focus-visible,
+.patient-cards__continue:focus-visible,
+.patient-cards__submit:focus-visible,
+.patient-cards__start:focus-visible,
+.patient-cards__review-edit:focus-visible,
+.patient-cards__review-errors-jump:focus-visible {
+	outline: 2px solid var(--patient-cards-accent);
+	outline-offset: 2px;
+	transition: outline-offset 150ms ease-out;
+}
+
+.patient-cards__submit[disabled],
+.patient-cards__continue[disabled] {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.patient-cards__start {
+	min-height: 44px;
+	min-width: 120px;
+	padding: 10px 18px;
+	border-radius: 6px;
+	border: 1px solid transparent;
+	background: var(--patient-cards-accent);
+	color: var(--patient-cards-accent-text);
+	font-size: 15px;
+	cursor: pointer;
+}
+
+.patient-cards__welcome-title {
+	font-size: 24px;
+	margin: 0 0 12px;
+	color: #222;
+}
+
+.patient-cards__welcome-description {
+	font-size: 16px;
+	color: #555;
+	line-height: 1.4;
+	margin: 0 0 24px;
+}
+
+.patient-cards__review-heading {
+	font-size: 20px;
+	margin: 0 0 16px;
+	color: #222;
+}
+
+.patient-cards__review-section {
+	margin-bottom: 16px;
+}
+
+.patient-cards__review-section-title {
+	font-size: 13px;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: #888;
+	margin: 0 0 8px;
+}
+
+.patient-cards__review-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.patient-cards__review-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr auto;
+	gap: 12px;
+	align-items: center;
+	padding: 8px 0;
+	border-bottom: 1px solid #f0f0f0;
+	list-style: none;
+}
+
+.patient-cards__review-label {
+	font-weight: 500;
+	color: #333;
+}
+
+.patient-cards__review-value {
+	color: #555;
+	margin: 0;
+}
+
+.patient-cards__review-empty {
+	color: #bbb;
+}
+
+.patient-cards__review-edit {
+	background: transparent;
+	color: var(--patient-cards-accent);
+	border: 1px solid var(--patient-cards-accent);
+	border-radius: 6px;
+	padding: 6px 12px;
+	min-height: 36px;
+	font-size: 14px;
+	cursor: pointer;
+}
+
+.patient-cards__review-errors {
+	background: var(--patient-cards-error-bg);
+	border: 1px solid var(--patient-cards-error);
+	border-radius: 6px;
+	padding: 12px 16px;
+	margin-bottom: 16px;
+}
+
+.patient-cards__review-errors-title {
+	font-size: 14px;
+	margin: 0 0 8px;
+	color: var(--patient-cards-error);
+}
+
+.patient-cards__review-errors-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.patient-cards__review-errors-item {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 12px;
+	padding: 4px 0;
+	color: var(--patient-cards-error);
+}
+
+.patient-cards__review-errors-jump {
+	background: transparent;
+	color: var(--patient-cards-error);
+	border: 1px solid var(--patient-cards-error);
+	border-radius: 4px;
+	padding: 4px 10px;
+	font-size: 13px;
+	cursor: pointer;
+}
+
+.patient-cards__card--confirmation .patient-cards__card-body {
+	text-align: center;
+	justify-content: center;
+	align-items: center;
+}
+
+.patient-cards__confirmation-check {
+	font-size: 64px;
+	color: #28a745;
+	margin-bottom: 12px;
+}
+
+.patient-cards__confirmation-heading {
+	font-size: 24px;
+	margin: 0 0 8px;
+	color: #222;
+}
+
+.patient-cards__confirmation-body {
+	font-size: 16px;
+	color: #555;
+	margin: 0;
+}
+
+.patient-cards__confirmation-check {
+	animation: patient-cards__check-draw 480ms ease-out;
+}
+
+@keyframes patient-cards__check-draw {
+	from {
+		opacity: 0;
+		transform: scale(0.6);
+	}
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
+/* Reduced motion: replace all transforms/keyframes with simple opacity fades. */
+@media (prefers-reduced-motion: reduce) {
+	.patient-cards__card {
+		animation: patient-cards__card-fade-in var(--patient-cards-transition) ease-out;
+	}
+	.patient-cards__confirmation-check {
+		animation: patient-cards__check-fade-in var(--patient-cards-transition) ease-out;
+	}
+	.patient-cards__continue:active:not(:disabled),
+	.patient-cards__submit:active:not(:disabled),
+	.patient-cards__start:active:not(:disabled) {
+		transform: none;
+	}
+	.patient-cards__progress-bar {
+		transition: none;
+	}
+	@keyframes patient-cards__card-fade-in {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+	@keyframes patient-cards__check-fade-in {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+}

--- a/src/components/icure-form/renderer/patient-cards/register.ts
+++ b/src/components/icure-form/renderer/patient-cards/register.ts
@@ -1,0 +1,7 @@
+import { IcurePatientCardsInternal } from './internal'
+
+// Internal element used by renderer="patient-cards". Registered here so the renderer module is
+// self-contained and the default theme can rely on a side-effect import without manual wiring.
+if (!customElements.get('icure-patient-cards-internal')) {
+	customElements.define('icure-patient-cards-internal', IcurePatientCardsInternal)
+}

--- a/src/components/icure-form/renderer/patient-cards/translation-keys.ts
+++ b/src/components/icure-form/renderer/patient-cards/translation-keys.ts
@@ -1,0 +1,74 @@
+/**
+ * Translation keys emitted by the patient-cards renderer for its chrome strings.
+ *
+ * Host apps provide translations via the existing `translationProvider` on `<icure-form>`. When the
+ * provider returns the key unchanged (no translation registered), the renderer falls back to the
+ * English defaults below.
+ *
+ * The full key set is exported as `PatientRendererKeys`. The defaults map is exported as
+ * `patientRendererDefaults`. Tests and integrators can rely on these constants.
+ */
+
+export const PatientRendererKeys = {
+	start: 'patient-renderer.start',
+	continue: 'patient-renderer.continue',
+	back: 'patient-renderer.back',
+	submit: 'patient-renderer.submit',
+	progress: 'patient-renderer.progress',
+	reviewHeading: 'patient-renderer.review-heading',
+	reviewEdit: 'patient-renderer.review-edit',
+	reviewEmpty: 'patient-renderer.review-empty',
+	reviewErrorsTitle: 'patient-renderer.review-errors-title',
+	confirmationHeading: 'patient-renderer.confirmation-heading',
+	confirmationBody: 'patient-renderer.confirmation-body',
+} as const
+
+export type PatientRendererKey = keyof typeof PatientRendererKeys
+
+export const patientRendererDefaults: Record<PatientRendererKey, string> = {
+	start: 'Start',
+	continue: 'Continue',
+	back: 'Back',
+	submit: 'Submit',
+	progress: '{current} / {total}',
+	reviewHeading: 'Review your answers',
+	reviewEdit: 'Edit',
+	reviewEmpty: '—',
+	reviewErrorsTitle: 'Please fix these before submitting',
+	confirmationHeading: 'Thank you',
+	confirmationBody: 'Your answers have been submitted.',
+}
+
+/**
+ * Resolve a chrome string using the supplied translation provider.
+ *
+ * Behaviour:
+ *   - If no provider or no language: returns the English default.
+ *   - Otherwise: calls `provider(language, key)`. If the result equals the key (i.e. no translation
+ *     registered for that key), returns the English default. Otherwise returns the provider's value.
+ *
+ * The `{current}` / `{total}` substitutions for the progress key are applied after translation
+ * lookup, so host translations can re-order tokens.
+ */
+export function resolveChrome(
+	provider: ((language: string, text: string) => string) | undefined,
+	language: string | undefined,
+	key: PatientRendererKey,
+	substitutions?: Record<string, string | number>,
+): string {
+	const fullKey = PatientRendererKeys[key]
+	const fallback = patientRendererDefaults[key]
+	let value = fallback
+	if (provider && language) {
+		const translated = provider(language, fullKey)
+		// When the provider knows nothing about the key, the convention is to return the key unchanged.
+		// Treat that as "use the English fallback".
+		value = translated && translated !== fullKey ? translated : fallback
+	}
+	if (substitutions) {
+		for (const [k, v] of Object.entries(substitutions)) {
+			value = value.split(`{${k}}`).join(String(v))
+		}
+	}
+	return value
+}

--- a/src/components/model/index.ts
+++ b/src/components/model/index.ts
@@ -147,6 +147,13 @@ export abstract class Field {
 	hasOther?: boolean
 	event?: string
 	payload?: unknown
+	hiddenForPatient?: boolean
+	/**
+	 * Patient-cards renderer only: when `true`, this Field is rendered on its own card regardless
+	 * of `questionsPerCard`. Adjacent fields are pushed to subsequent cards. Has no effect on the
+	 * clinician renderer.
+	 */
+	standalone?: boolean
 
 	label(): string {
 		return this.field
@@ -232,7 +239,7 @@ export abstract class Field {
 	abstract copyIfNeeded(properties: Partial<Field>): Field
 
 	static parse(json: Field): Field {
-		return (
+		const result =
 			(
 				{
 					'text-field': () => new TextField(json.field, { ...json }),
@@ -250,7 +257,13 @@ export abstract class Field {
 					action: () => new Button(json.field, { ...json }),
 				} as { [key: string]: () => Field }
 			)[json.type as string]?.() ?? new TextField(json.field, { ...json })
-		)
+		if ((json as any).hiddenForPatient !== undefined) {
+			result.hiddenForPatient = !!(json as any).hiddenForPatient
+		}
+		if ((json as any).standalone !== undefined) {
+			result.standalone = !!(json as any).standalone
+		}
+		return result
 	}
 
 	// noinspection JSUnusedGlobalSymbols
@@ -288,6 +301,8 @@ export abstract class Field {
 		shortLabel: string | undefined
 		computedProperties: { [key: string]: string } | undefined
 		value: string | undefined
+		hiddenForPatient: boolean | undefined
+		standalone: boolean | undefined
 	} {
 		return {
 			field: this.field,
@@ -309,6 +324,8 @@ export abstract class Field {
 			sortOptions: this.sortOptions,
 			width: this.width,
 			styleOptions: this.styleOptions,
+			hiddenForPatient: this.hiddenForPatient,
+			standalone: this.standalone,
 		}
 	}
 }
@@ -1028,6 +1045,7 @@ export class Group {
 	computedProperties?: { [_key: string]: string }
 	width?: number
 	styleOptions?: { [_key: string]: unknown }
+	hiddenForPatient?: boolean
 
 	constructor(
 		title: string,
@@ -1040,6 +1058,7 @@ export class Group {
 			computedProperties,
 			width,
 			styleOptions,
+			hiddenForPatient,
 		}: {
 			borderless?: boolean
 			translate?: boolean
@@ -1048,6 +1067,7 @@ export class Group {
 			computedProperties?: { [_key: string]: string }
 			width?: number
 			styleOptions?: { [_key: string]: unknown }
+			hiddenForPatient?: boolean
 		},
 	) {
 		this.group = title
@@ -1060,6 +1080,7 @@ export class Group {
 		this.computedProperties = computedProperties
 		this.width = width
 		this.styleOptions = styleOptions
+		this.hiddenForPatient = hiddenForPatient
 	}
 
 	copyIfNeeded(properties: Partial<Group>): Group {
@@ -1074,6 +1095,7 @@ export class Group {
 		group,
 		translate,
 		width,
+		hiddenForPatient,
 	}: {
 		group: string
 		fields?: Array<Field | Group | Subform>
@@ -1083,6 +1105,7 @@ export class Group {
 		rowSpan?: number
 		computedProperties?: { [_key: string]: string }
 		width?: number
+		hiddenForPatient?: boolean
 	}): Group {
 		return new Group(
 			group,
@@ -1099,6 +1122,7 @@ export class Group {
 				translate: translate,
 				computedProperties: computedProperties,
 				width: width,
+				hiddenForPatient: hiddenForPatient,
 			},
 		)
 	}
@@ -1112,6 +1136,7 @@ export class Group {
 			translatable: this.translate,
 			span: this.span,
 			width: this.width,
+			hiddenForPatient: this.hiddenForPatient,
 		}
 	}
 }
@@ -1128,6 +1153,7 @@ export class Subform {
 	width?: number
 	styleOptions?: { [_key: string]: unknown }
 	labels: Labels
+	hiddenForPatient?: boolean
 
 	constructor(
 		title: string,
@@ -1142,6 +1168,7 @@ export class Subform {
 			styleOptions,
 			refs,
 			labels,
+			hiddenForPatient,
 		}: {
 			id?: string
 			shortLabel?: string
@@ -1152,6 +1179,7 @@ export class Subform {
 			styleOptions?: { [_key: string]: unknown }
 			refs?: string[]
 			labels?: Labels
+			hiddenForPatient?: boolean
 		},
 	) {
 		this.id = id || title
@@ -1164,6 +1192,7 @@ export class Subform {
 		this.styleOptions = styleOptions
 		this.refs = refs
 		this.labels = labels ?? {}
+		this.hiddenForPatient = hiddenForPatient
 	}
 
 	copyIfNeeded(properties: Partial<Subform>): Subform {
@@ -1182,6 +1211,7 @@ export class Subform {
 		styleOptions?: { [_key: string]: unknown }
 		labels?: Labels
 		id: string
+		hiddenForPatient?: boolean
 	}): Subform {
 		return new Subform(json.subform, json.forms ?? {}, {
 			id: json.id,
@@ -1192,6 +1222,7 @@ export class Subform {
 			styleOptions: json.styleOptions,
 			refs: json.refs,
 			labels: json.labels,
+			hiddenForPatient: json.hiddenForPatient,
 		})
 	}
 
@@ -1204,6 +1235,7 @@ export class Subform {
 			computedProperties: this.computedProperties,
 			width: this.width,
 			styleOptions: this.styleOptions,
+			hiddenForPatient: this.hiddenForPatient,
 		}
 	}
 }
@@ -1212,12 +1244,14 @@ export class Section {
 	fields: Array<Field | Group | Subform>
 	description?: string
 	keywords?: string[]
+	hiddenForPatient?: boolean
 
-	constructor(title: string, fields: Array<Field | Group | Subform>, description?: string, keywords?: string[]) {
+	constructor(title: string, fields: Array<Field | Group | Subform>, description?: string, keywords?: string[], hiddenForPatient?: boolean) {
 		this.section = title
 		this.fields = fields
 		this.description = description
 		this.keywords = keywords
+		this.hiddenForPatient = hiddenForPatient
 	}
 
 	static parse(json: {
@@ -1227,6 +1261,7 @@ export class Section {
 		sections?: Array<Field | Group | Subform>
 		description?: string
 		keywords?: string[]
+		hiddenForPatient?: boolean
 	}): Section {
 		return new Section(
 			json.section,
@@ -1239,6 +1274,7 @@ export class Section {
 			),
 			json.description,
 			json.keywords,
+			json.hiddenForPatient,
 		)
 	}
 
@@ -1247,12 +1283,14 @@ export class Section {
 		keywords?: string[]
 		description?: string
 		fields: (Field | Group | Subform)[]
+		hiddenForPatient?: boolean
 	} {
 		return {
 			section: this.section,
 			fields: this.fields.map((f: Field | Group | Subform) => (f && f.toJson ? f.toJson() : JSON.stringify(f))),
 			description: this.description,
 			keywords: this.keywords,
+			hiddenForPatient: this.hiddenForPatient,
 		}
 	}
 }

--- a/test/e2e/patient-cards-phase1.spec.ts
+++ b/test/e2e/patient-cards-phase1.spec.ts
@@ -1,0 +1,622 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ============================================================
+// Phase 1: dispatch + linear nav + hiddenForPatient cascade + Subform recursion
+// ============================================================
+
+// Helpers ---------------------------------------------------------
+
+async function gotoHarness(page: Page) {
+	await page.goto('/')
+	await page.waitForFunction(() => typeof (window as any).initForm === 'function', { timeout: 10_000 })
+}
+
+async function initPatientCards(page: Page, yaml: string) {
+	return await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'patient-cards' }), yaml)
+}
+
+async function initClinicianRenderer(page: Page, yaml: string) {
+	return await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'form' }), yaml)
+}
+
+async function waitForInternal(page: Page) {
+	await page.waitForFunction(
+		() => {
+			const root = document.querySelector('icure-form')?.shadowRoot
+			return !!root?.querySelector('icure-patient-cards-internal')
+		},
+		{ timeout: 15_000 },
+	)
+	// Allow Lit to render the internal element's shadow DOM.
+	await page.waitForFunction(
+		() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal')
+			return !!(internal as any)?.shadowRoot?.querySelector('.patient-cards')
+		},
+		{ timeout: 15_000 },
+	)
+}
+
+async function getCardState(page: Page) {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const root = internal?.shadowRoot
+		if (!root) return null
+		const wrapper = root.querySelector('.patient-cards')
+		const card = root.querySelector('.patient-cards__card')
+		return {
+			currentCardIndex: parseInt(wrapper?.getAttribute('data-current-card-index') ?? '-1', 10),
+			totalCards: parseInt(wrapper?.getAttribute('data-total-cards') ?? '-1', 10),
+			sectionTitle: card?.getAttribute('data-card-section') ?? null,
+			progressText: root.querySelector('.patient-cards__progress-text')?.textContent?.trim() ?? null,
+			hasBack: !!root.querySelector('.patient-cards__back'),
+			hasContinue: !!root.querySelector('.patient-cards__continue'),
+			hasSubmit: !!root.querySelector('.patient-cards__submit'),
+			progressBarWidth: (root.querySelector('.patient-cards__progress-bar') as HTMLElement | null)?.style.width ?? null,
+		}
+	})
+}
+
+async function clickContinue(page: Page) {
+	await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector('[class*="patient-cards__continue"]') as HTMLElement
+		btn?.click()
+	})
+	await page.waitForTimeout(100)
+}
+
+async function clickBack(page: Page) {
+	await page.evaluate(() => {
+		const btn = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal')?.shadowRoot?.querySelector('.patient-cards__back') as HTMLElement
+		btn?.click()
+	})
+	await page.waitForTimeout(100)
+}
+
+// Phase 2 introduced a welcome stage. Phase 1 navigation tests run their assertions against the
+// input stage, so they need to advance past welcome first.
+async function clickStartIfPresent(page: Page) {
+	await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector('.patient-cards__start') as HTMLElement
+		btn?.click()
+	})
+	await page.waitForTimeout(100)
+}
+
+// ============================================================
+// Group 1: dispatch
+// ============================================================
+test.describe('Phase 1 / dispatch', () => {
+	const yaml = `
+form: Dispatch
+sections:
+  - section: A
+    fields:
+      - field: Q1
+        type: text-field
+`
+
+	test('renderer="patient-cards" mounts the patient internal element', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		const tag = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal')
+			return internal?.tagName.toLowerCase() ?? null
+		})
+		expect(tag).toBe('icure-patient-cards-internal')
+	})
+
+	test('renderer="form" (default) does NOT mount the patient internal element', async ({ page }) => {
+		await gotoHarness(page)
+		await initClinicianRenderer(page, yaml)
+		// Wait for clinician shadow content
+		await page.waitForFunction(
+			() => {
+				const el = document.querySelector('icure-form')
+				if (!el?.shadowRoot) return false
+				return el.shadowRoot.querySelector('.icure-form') !== null
+			},
+			{ timeout: 15_000 },
+		)
+		const internalPresent = await page.evaluate(() => {
+			return !!document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal')
+		})
+		expect(internalPresent).toBe(false)
+	})
+})
+
+// ============================================================
+// Group 2: linear navigation
+// ============================================================
+test.describe('Phase 1 / linear navigation', () => {
+	const threeQuestionYaml = `
+form: Linear
+sections:
+  - section: Demographics
+    fields:
+      - field: First name
+        type: text-field
+      - field: Last name
+        type: text-field
+      - field: Age
+        type: number-field
+`
+
+	test('three text fields produce three cards, one field per card', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, threeQuestionYaml)
+		await waitForInternal(page)
+		await clickStartIfPresent(page)
+		const s = await getCardState(page)
+		expect(s).not.toBeNull()
+		expect(s!.totalCards).toBe(3)
+		expect(s!.currentCardIndex).toBe(0)
+		expect(s!.sectionTitle).toBe('Demographics')
+		expect(s!.progressText).toBe('1 / 3')
+	})
+
+	test('On the first input card, Continue is present and (with no validators) Back returns to welcome', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, threeQuestionYaml)
+		await waitForInternal(page)
+		await clickStartIfPresent(page)
+		const s = await getCardState(page)
+		// Phase 2 introduced a welcome stage; Back from first input card returns to welcome.
+		expect(s!.hasContinue).toBe(true)
+		expect(s!.hasSubmit).toBe(false)
+	})
+
+	test('Continue advances; Back returns; Submit replaces Continue on last card', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, threeQuestionYaml)
+		await waitForInternal(page)
+		await clickStartIfPresent(page)
+
+		// Card 0 -> Card 1
+		await clickContinue(page)
+		let s = await getCardState(page)
+		expect(s!.currentCardIndex).toBe(1)
+		expect(s!.hasBack).toBe(true)
+		expect(s!.hasContinue).toBe(true)
+		expect(s!.hasSubmit).toBe(false)
+		expect(s!.progressText).toBe('2 / 3')
+
+		// Card 1 -> Card 2 (last input card; Continue exists, points to review).
+		await clickContinue(page)
+		s = await getCardState(page)
+		expect(s!.currentCardIndex).toBe(2)
+		expect(s!.hasBack).toBe(true)
+		expect(s!.hasContinue).toBe(true)
+		expect(s!.hasSubmit).toBe(false)
+		expect(s!.progressText).toBe('3 / 3')
+
+		// Back to Card 1
+		await clickBack(page)
+		s = await getCardState(page)
+		expect(s!.currentCardIndex).toBe(1)
+	})
+
+	test('progress bar width tracks index', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, threeQuestionYaml)
+		await waitForInternal(page)
+		await clickStartIfPresent(page)
+		// 1/3 = 33.33%
+		let s = await getCardState(page)
+		expect(s!.progressBarWidth).toMatch(/^33\.?\d*%$/)
+		await clickContinue(page)
+		s = await getCardState(page)
+		expect(s!.progressBarWidth).toMatch(/^66\.?\d*%$/)
+		await clickContinue(page)
+		s = await getCardState(page)
+		expect(s!.progressBarWidth).toBe('100%')
+	})
+})
+
+// ============================================================
+// Group 3: hiddenForPatient cascade
+// ============================================================
+test.describe('Phase 1 / hiddenForPatient cascade', () => {
+	test('Field-level hiddenForPatient excludes only that field', async ({ page }) => {
+		const yaml = `
+form: FieldHidden
+sections:
+  - section: S
+    fields:
+      - field: Visible1
+        type: text-field
+      - field: Hidden1
+        type: text-field
+        hiddenForPatient: true
+      - field: Visible2
+        type: text-field
+`
+		await gotoHarness(page)
+		const flat = await page.evaluate(
+			(y) =>
+				(window as any).patientCardsFlatten({
+					form: 'FieldHidden',
+					sections: [
+						{
+							section: 'S',
+							fields: [
+								{ field: 'Visible1', type: 'text-field' },
+								{ field: 'Hidden1', type: 'text-field', hiddenForPatient: true },
+								{ field: 'Visible2', type: 'text-field' },
+							],
+						},
+					],
+				}),
+			yaml,
+		)
+		expect(flat.map((c: any) => c.fieldLabels[0])).toEqual(['Visible1', 'Visible2'])
+	})
+
+	test('Group-level hiddenForPatient cascades and excludes all nested fields', async ({ page }) => {
+		await gotoHarness(page)
+		const flat = await page.evaluate(() =>
+			(window as any).patientCardsFlatten({
+				form: 'GroupHidden',
+				sections: [
+					{
+						section: 'S',
+						fields: [
+							{ field: 'TopVisible', type: 'text-field' },
+							{
+								group: 'HiddenGroup',
+								hiddenForPatient: true,
+								fields: [
+									{ field: 'Inner1', type: 'text-field' },
+									{ field: 'Inner2', type: 'text-field' },
+								],
+							},
+							{ field: 'TailVisible', type: 'text-field' },
+						],
+					},
+				],
+			}),
+		)
+		expect(flat.map((c: any) => c.fieldLabels[0])).toEqual(['TopVisible', 'TailVisible'])
+	})
+
+	test('Section-level hiddenForPatient cascades and excludes the whole section', async ({ page }) => {
+		await gotoHarness(page)
+		const flat = await page.evaluate(() =>
+			(window as any).patientCardsFlatten({
+				form: 'SectionHidden',
+				sections: [
+					{ section: 'Visible', fields: [{ field: 'A', type: 'text-field' }] },
+					{ section: 'Hidden', hiddenForPatient: true, fields: [{ field: 'B', type: 'text-field' }] },
+					{ section: 'Visible2', fields: [{ field: 'C', type: 'text-field' }] },
+				],
+			}),
+		)
+		const sections = flat.map((c: any) => c.sectionTitle)
+		const labels = flat.map((c: any) => c.fieldLabels[0])
+		expect(sections).toEqual(['Visible', 'Visible2'])
+		expect(labels).toEqual(['A', 'C'])
+	})
+
+	test('Subform-level hiddenForPatient cascades and excludes the embedded form', async ({ page }) => {
+		await gotoHarness(page)
+		const flat = await page.evaluate(() =>
+			(window as any).patientCardsFlatten({
+				form: 'SubformHidden',
+				sections: [
+					{
+						section: 'Main',
+						fields: [
+							{ field: 'Before', type: 'text-field' },
+							{
+								subform: 'Sub',
+								id: 'sub',
+								hiddenForPatient: true,
+								forms: {
+									'sub-template': {
+										form: 'SubInner',
+										sections: [
+											{ section: 'Inner', fields: [{ field: 'InnerField', type: 'text-field' }] },
+										],
+									},
+								},
+							},
+							{ field: 'After', type: 'text-field' },
+						],
+					},
+				],
+			}),
+		)
+		expect(flat.map((c: any) => c.fieldLabels[0])).toEqual(['Before', 'After'])
+	})
+
+	test('cascade applies through nested Groups', async ({ page }) => {
+		await gotoHarness(page)
+		const flat = await page.evaluate(() =>
+			(window as any).patientCardsFlatten({
+				form: 'NestedGroupHidden',
+				sections: [
+					{
+						section: 'S',
+						fields: [
+							{
+								group: 'OuterGroup',
+								fields: [
+									{ field: 'OuterVisible', type: 'text-field' },
+									{
+										group: 'InnerHidden',
+										hiddenForPatient: true,
+										fields: [{ field: 'DeepHidden', type: 'text-field' }],
+									},
+								],
+							},
+						],
+					},
+				],
+			}),
+		)
+		expect(flat.map((c: any) => c.fieldLabels[0])).toEqual(['OuterVisible'])
+	})
+
+	test('hiddenForPatient has NO effect on the clinician renderer', async ({ page }) => {
+		const yaml = `
+form: HiddenNoEffect
+sections:
+  - section: S
+    fields:
+      - field: Visible
+        type: text-field
+      - field: HiddenInPatient
+        type: text-field
+        hiddenForPatient: true
+`
+		await gotoHarness(page)
+		await initClinicianRenderer(page, yaml)
+		await page.waitForFunction(
+			() => {
+				const root = document.querySelector('icure-form')?.shadowRoot
+				return !!root?.querySelector('.icure-form')
+			},
+			{ timeout: 15_000 },
+		)
+		await page.waitForTimeout(500)
+		const visibleLabels = await page.evaluate(() => {
+			const root = document.querySelector('icure-form')?.shadowRoot
+			if (!root) return []
+			const out: string[] = []
+			root.querySelectorAll('.icure-form-field').forEach((el) => {
+				out.push((el as any).label)
+			})
+			return out
+		})
+		expect(visibleLabels).toContain('Visible')
+		expect(visibleLabels).toContain('HiddenInPatient')
+	})
+})
+
+// ============================================================
+// Group 4: Subform transparent recursion
+// ============================================================
+test.describe('Phase 1 / Subform recursion', () => {
+	test('Subform fields appear inline in card sequence between sibling fields', async ({ page }) => {
+		await gotoHarness(page)
+		const flat = await page.evaluate(() =>
+			(window as any).patientCardsFlatten({
+				form: 'WithSub',
+				sections: [
+					{
+						section: 'Main',
+						fields: [
+							{ field: 'Before', type: 'text-field' },
+							{
+								subform: 'Sub',
+								id: 'sub',
+								forms: {
+									'sub-template': {
+										form: 'SubInner',
+										sections: [
+											{
+												section: 'Inner',
+												fields: [
+													{ field: 'I1', type: 'text-field' },
+													{ field: 'I2', type: 'text-field' },
+												],
+											},
+										],
+									},
+								},
+							},
+							{ field: 'After', type: 'text-field' },
+						],
+					},
+				],
+			}),
+		)
+		// Cards: Before(Main), I1(Inner), I2(Inner), After(Main)
+		expect(flat.map((c: any) => c.fieldLabels[0])).toEqual(['Before', 'I1', 'I2', 'After'])
+		expect(flat.map((c: any) => c.sectionTitle)).toEqual(['Main', 'Inner', 'Inner', 'Main'])
+	})
+
+	test('Subform with multiple form templates contributes fields from every template', async ({ page }) => {
+		await gotoHarness(page)
+		const flat = await page.evaluate(() =>
+			(window as any).patientCardsFlatten({
+				form: 'MultiTemplate',
+				sections: [
+					{
+						section: 'Main',
+						fields: [
+							{
+								subform: 'Sub',
+								id: 'sub',
+								forms: {
+									a: { form: 'A', sections: [{ section: 'A-sec', fields: [{ field: 'A1', type: 'text-field' }] }] },
+									b: { form: 'B', sections: [{ section: 'B-sec', fields: [{ field: 'B1', type: 'text-field' }] }] },
+								},
+							},
+						],
+					},
+				],
+			}),
+		)
+		const labels = flat.map((c: any) => c.fieldLabels[0]).sort()
+		expect(labels).toEqual(['A1', 'B1'])
+	})
+
+	test('Cyclic Subform references are skipped with console.warn (no infinite loop)', async ({ page }) => {
+		await gotoHarness(page)
+		const result = await page.evaluate(() => (window as any).testCyclicSubformFlatten())
+		// Visited-set guard ensures finite cardCount (no infinite loop).
+		expect(typeof result.cardCount).toBe('number')
+		// At least one warning containing "Cycle detected" was emitted.
+		const matched = (result.warnings as string[]).some((w) => w.includes('Cycle detected'))
+		expect(matched).toBe(true)
+	})
+})
+
+// ============================================================
+// Group 5: parse/toJson round-trip
+// ============================================================
+test.describe('Phase 1 / parse and toJson round-trip', () => {
+	test('hiddenForPatient round-trips at Field level', async ({ page }) => {
+		await gotoHarness(page)
+		const out = await page.evaluate(() =>
+			(window as any).formToJson({
+				form: 'RT',
+				sections: [
+					{
+						section: 'S',
+						fields: [{ field: 'A', type: 'text-field', hiddenForPatient: true }],
+					},
+				],
+			}),
+		)
+		expect(out.sections[0].fields[0].hiddenForPatient).toBe(true)
+	})
+
+	test('hiddenForPatient round-trips at Section level', async ({ page }) => {
+		await gotoHarness(page)
+		const out = await page.evaluate(() =>
+			(window as any).formToJson({
+				form: 'RT',
+				sections: [
+					{
+						section: 'S',
+						hiddenForPatient: true,
+						fields: [{ field: 'A', type: 'text-field' }],
+					},
+				],
+			}),
+		)
+		expect(out.sections[0].hiddenForPatient).toBe(true)
+	})
+
+	test('hiddenForPatient round-trips at Group level', async ({ page }) => {
+		await gotoHarness(page)
+		const out = await page.evaluate(() =>
+			(window as any).formToJson({
+				form: 'RT',
+				sections: [
+					{
+						section: 'S',
+						fields: [
+							{
+								group: 'G',
+								hiddenForPatient: true,
+								fields: [{ field: 'A', type: 'text-field' }],
+							},
+						],
+					},
+				],
+			}),
+		)
+		const grp = out.sections[0].fields.find((f: any) => f.group === 'G')
+		expect(grp.hiddenForPatient).toBe(true)
+	})
+
+	test('hiddenForPatient round-trips at Subform level', async ({ page }) => {
+		await gotoHarness(page)
+		const out = await page.evaluate(() =>
+			(window as any).formToJson({
+				form: 'RT',
+				sections: [
+					{
+						section: 'S',
+						fields: [
+							{
+								subform: 'Sub',
+								id: 'sub',
+								hiddenForPatient: true,
+								forms: {
+									t: { form: 'T', sections: [{ section: 'I', fields: [{ field: 'X', type: 'text-field' }] }] },
+								},
+							},
+						],
+					},
+				],
+			}),
+		)
+		const sub = out.sections[0].fields.find((f: any) => f.subform === 'sub')
+		expect(sub.hiddenForPatient).toBe(true)
+	})
+
+	test('absent hiddenForPatient remains undefined / falsy after round-trip', async ({ page }) => {
+		await gotoHarness(page)
+		const out = await page.evaluate(() =>
+			(window as any).formToJson({
+				form: 'RT',
+				sections: [
+					{
+						section: 'S',
+						fields: [{ field: 'A', type: 'text-field' }],
+					},
+				],
+			}),
+		)
+		expect(!!out.sections[0].fields[0].hiddenForPatient).toBe(false)
+		expect(!!out.sections[0].hiddenForPatient).toBe(false)
+	})
+})
+
+// ============================================================
+// Group 6: rendering integration - card body shows expected field component
+// ============================================================
+test.describe('Phase 1 / rendering integration', () => {
+	test('current card renders the expected field component', async ({ page }) => {
+		const yaml = `
+form: Render
+sections:
+  - section: Demographics
+    fields:
+      - field: First name
+        type: text-field
+      - field: Age
+        type: number-field
+`
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickStartIfPresent(page)
+
+		// First card: text-field
+		let typeOnCard = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const body = internal?.shadowRoot?.querySelector('.patient-cards__card-body')
+			const fieldEl = body?.querySelector('icure-form-text-field, icure-form-number-field')
+			return fieldEl?.tagName.toLowerCase() ?? null
+		})
+		expect(typeOnCard).toBe('icure-form-text-field')
+
+		await clickContinue(page)
+
+		typeOnCard = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const body = internal?.shadowRoot?.querySelector('.patient-cards__card-body')
+			const fieldEl = body?.querySelector('icure-form-text-field, icure-form-number-field')
+			return fieldEl?.tagName.toLowerCase() ?? null
+		})
+		expect(typeOnCard).toBe('icure-form-number-field')
+	})
+})

--- a/test/e2e/patient-cards-phase2.spec.ts
+++ b/test/e2e/patient-cards-phase2.spec.ts
@@ -1,0 +1,406 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ============================================================
+// Phase 2: welcome / review / confirmation / patient-form-submit
+// ============================================================
+
+async function gotoHarness(page: Page) {
+	await page.goto('/')
+	await page.waitForFunction(() => typeof (window as any).initForm === 'function', { timeout: 10_000 })
+}
+
+async function initPatientCards(page: Page, yaml: string) {
+	return await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'patient-cards' }), yaml)
+}
+
+async function waitForInternal(page: Page) {
+	await page.waitForFunction(
+		() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards')
+		},
+		{ timeout: 15_000 },
+	)
+}
+
+async function getStage(page: Page): Promise<string | null> {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		return internal?.shadowRoot?.querySelector('.patient-cards')?.getAttribute('data-stage') ?? null
+	})
+}
+
+async function clickByClass(page: Page, cls: string) {
+	const ok = await page.evaluate((c: string) => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector(`.${c}`) as HTMLElement | null
+		if (!btn) return false
+		btn.click()
+		return true
+	}, cls)
+	if (!ok) throw new Error(`Button .${cls} not found`)
+	await page.waitForTimeout(100)
+}
+
+async function clickEditForCardIndex(page: Page, cardIndex: number) {
+	const ok = await page.evaluate((idx: number) => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const row = internal?.shadowRoot?.querySelector(`.patient-cards__review-row[data-card-index="${idx}"]`)
+		const btn = row?.querySelector('.patient-cards__review-edit') as HTMLElement | null
+		if (!btn) return false
+		btn.click()
+		return true
+	}, cardIndex)
+	if (!ok) throw new Error(`Edit button for card-index ${cardIndex} not found`)
+	await page.waitForTimeout(100)
+}
+
+async function getCurrentCardIndex(page: Page): Promise<number | null> {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const root = internal?.shadowRoot?.querySelector('.patient-cards')
+		const idx = root?.getAttribute('data-current-card-index')
+		return idx === null || idx === undefined ? null : parseInt(idx, 10)
+	})
+}
+
+// Set a string value on the BridgedFormValuesContainer for a given field label, then wait for re-render.
+async function setStringValue(page: Page, label: string, value: string, language = 'en') {
+	await page.evaluate(
+		({ label, value, language }: { label: string; value: string; language: string }) => {
+			const fvc = (window as any).__currentFvc
+			fvc.setValue(label, language, { content: { [language]: { type: 'string', value } } })
+		},
+		{ label, value, language },
+	)
+	await page.waitForTimeout(200)
+}
+
+// ============================================================
+// Welcome card
+// ============================================================
+test.describe('Phase 2 / welcome card', () => {
+	const yaml = `
+form: Patient intake
+description: This is a short intake form
+sections:
+  - section: Demographics
+    fields:
+      - field: First name
+        type: text-field
+      - field: Last name
+        type: text-field
+`
+
+	test('initial stage is welcome', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		expect(await getStage(page)).toBe('welcome')
+	})
+
+	test('welcome shows form title and description', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		const content = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const r = internal?.shadowRoot
+			return {
+				title: r?.querySelector('.patient-cards__welcome-title')?.textContent?.trim() ?? null,
+				description: r?.querySelector('.patient-cards__welcome-description')?.textContent?.trim() ?? null,
+				hasStart: !!r?.querySelector('.patient-cards__start'),
+			}
+		})
+		expect(content.title).toBe('Patient intake')
+		expect(content.description).toBe('This is a short intake form')
+		expect(content.hasStart).toBe(true)
+	})
+
+	test('Start button advances to first input card', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		expect(await getStage(page)).toBe('input')
+		expect(await getCurrentCardIndex(page)).toBe(0)
+	})
+
+	test('welcome is not counted in progress (progress shows 1 / 2 on first input card)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const progressText = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return internal?.shadowRoot?.querySelector('.patient-cards__progress-text')?.textContent?.trim() ?? null
+		})
+		expect(progressText).toBe('1 / 2')
+	})
+
+	test('Back from first input card returns to welcome', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await clickByClass(page, 'patient-cards__back')
+		expect(await getStage(page)).toBe('welcome')
+	})
+
+	test('welcome renders even when description is absent', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(
+			page,
+			`
+form: Onlytitle
+sections:
+  - section: S
+    fields:
+      - field: Q
+        type: text-field
+`,
+		)
+		await waitForInternal(page)
+		const result = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const r = internal?.shadowRoot
+			return {
+				title: r?.querySelector('.patient-cards__welcome-title')?.textContent?.trim() ?? null,
+				hasDescription: !!r?.querySelector('.patient-cards__welcome-description'),
+				hasStart: !!r?.querySelector('.patient-cards__start'),
+			}
+		})
+		expect(result.title).toBe('Onlytitle')
+		expect(result.hasDescription).toBe(false)
+		expect(result.hasStart).toBe(true)
+	})
+})
+
+// ============================================================
+// Card sequence -> review
+// ============================================================
+test.describe('Phase 2 / card sequence -> review', () => {
+	const yaml = `
+form: F
+description: D
+sections:
+  - section: A
+    fields:
+      - field: Q1
+        type: text-field
+      - field: Q2
+        type: text-field
+  - section: B
+    fields:
+      - field: Q3
+        type: text-field
+`
+
+	test('Continue on last input card goes to review', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		// 1 -> 2
+		await clickByClass(page, 'patient-cards__continue')
+		// 2 -> 3 (last)
+		await clickByClass(page, 'patient-cards__continue')
+		expect(await getStage(page)).toBe('input')
+		expect(await getCurrentCardIndex(page)).toBe(2)
+		// 3 -> review
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		expect(await getStage(page)).toBe('review')
+	})
+
+	test('review is not counted in progress (no progress chrome on review stage)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await clickByClass(page, 'patient-cards__continue')
+		await clickByClass(page, 'patient-cards__continue')
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		const hasProgress = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards__progress')
+		})
+		expect(hasProgress).toBe(false)
+	})
+})
+
+// ============================================================
+// Review card content + edit-jumps
+// ============================================================
+test.describe('Phase 2 / review card', () => {
+	const yaml = `
+form: F
+description: D
+sections:
+  - section: A
+    fields:
+      - field: First name
+        type: text-field
+      - field: Last name
+        type: text-field
+  - section: B
+    fields:
+      - field: City
+        type: text-field
+`
+
+	async function navigateToReview(page: Page) {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await clickByClass(page, 'patient-cards__continue')
+		await clickByClass(page, 'patient-cards__continue')
+		await clickByClass(page, 'patient-cards__continue--to-review')
+	}
+
+	test('review lists all field labels grouped by section', async ({ page }) => {
+		await navigateToReview(page)
+		const dom = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const r = internal?.shadowRoot
+			const sections = Array.from(r?.querySelectorAll('.patient-cards__review-section-title') ?? []).map((e) => (e as HTMLElement).textContent?.trim())
+			const labels = Array.from(r?.querySelectorAll('.patient-cards__review-label') ?? []).map((e) => (e as HTMLElement).textContent?.trim())
+			return { sections, labels }
+		})
+		expect(dom.sections).toEqual(['A', 'B'])
+		expect(dom.labels).toEqual(['First name', 'Last name', 'City'])
+	})
+
+	test('review shows actual entered values', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		// Set values BEFORE entering the input stage (it doesn't matter when — they're on the container)
+		await setStringValue(page, 'First name', 'Alice')
+		await setStringValue(page, 'Last name', 'Smith')
+		await setStringValue(page, 'City', 'Brussels')
+		await clickByClass(page, 'patient-cards__start')
+		await clickByClass(page, 'patient-cards__continue')
+		await clickByClass(page, 'patient-cards__continue')
+		await clickByClass(page, 'patient-cards__continue--to-review')
+
+		const values = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return Array.from(internal?.shadowRoot?.querySelectorAll('.patient-cards__review-value') ?? []).map((e) => (e as HTMLElement).textContent?.trim())
+		})
+		expect(values).toEqual(['Alice', 'Smith', 'Brussels'])
+	})
+
+	test('empty fields render an em-dash placeholder', async ({ page }) => {
+		await navigateToReview(page)
+		const placeholders = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return Array.from(internal?.shadowRoot?.querySelectorAll('.patient-cards__review-empty') ?? []).length
+		})
+		expect(placeholders).toBe(3)
+	})
+
+	test('Edit button jumps to specific input card with cameFromReview semantics', async ({ page }) => {
+		await navigateToReview(page)
+		await clickEditForCardIndex(page, 1) // jump to 'Last name' card (index 1)
+		expect(await getStage(page)).toBe('input')
+		expect(await getCurrentCardIndex(page)).toBe(1)
+		// The Continue button should be the "return to review" variant
+		const hasReturnToReview = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards__continue--return-to-review')
+		})
+		expect(hasReturnToReview).toBe(true)
+	})
+
+	test('Continue from edit-jumped card returns directly to review', async ({ page }) => {
+		await navigateToReview(page)
+		await clickEditForCardIndex(page, 0)
+		await clickByClass(page, 'patient-cards__continue--return-to-review')
+		expect(await getStage(page)).toBe('review')
+	})
+
+	test('Back from review returns to the last input card', async ({ page }) => {
+		await navigateToReview(page)
+		await clickByClass(page, 'patient-cards__back')
+		expect(await getStage(page)).toBe('input')
+		expect(await getCurrentCardIndex(page)).toBe(2) // last card index
+	})
+})
+
+// ============================================================
+// Submit + confirmation
+// ============================================================
+test.describe('Phase 2 / submit and confirmation', () => {
+	const yaml = `
+form: F
+description: D
+sections:
+  - section: A
+    fields:
+      - field: Q1
+        type: text-field
+`
+
+	async function navigateToReview(page: Page) {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await clickByClass(page, 'patient-cards__continue--to-review')
+	}
+
+	test('Submit on review fires patient-form-submit with detail.submittedAt', async ({ page }) => {
+		await navigateToReview(page)
+		// Hook the event before clicking.
+		await page.evaluate(() => {
+			const w = window as any
+			w.__submitEventCount = 0
+			w.__submitEventDetail = null
+			const el = document.querySelector('icure-form')
+			el?.addEventListener('patient-form-submit', (e: Event) => {
+				w.__submitEventCount++
+				w.__submitEventDetail = (e as CustomEvent).detail
+			})
+		})
+		await clickByClass(page, 'patient-cards__submit')
+		const { count, detail } = await page.evaluate(() => ({ count: (window as any).__submitEventCount, detail: (window as any).__submitEventDetail }))
+		expect(count).toBe(1)
+		expect(detail).toBeTruthy()
+		expect(detail.submittedAt).toBeTruthy()
+		// submittedAt should be a Date-ish (will be serialized to ISO string by page.evaluate's structured clone)
+		const ts = new Date(detail.submittedAt).getTime()
+		expect(Number.isFinite(ts)).toBe(true)
+	})
+
+	test('After submit, confirmation stage is shown', async ({ page }) => {
+		await navigateToReview(page)
+		await clickByClass(page, 'patient-cards__submit')
+		expect(await getStage(page)).toBe('confirmation')
+		const heading = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return internal?.shadowRoot?.querySelector('.patient-cards__confirmation-heading')?.textContent?.trim() ?? null
+		})
+		expect(heading).toBe('Thank you')
+	})
+
+	test('No Back button is available on confirmation', async ({ page }) => {
+		await navigateToReview(page)
+		await clickByClass(page, 'patient-cards__submit')
+		const hasBack = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards__back')
+		})
+		expect(hasBack).toBe(false)
+	})
+
+	test('Confirmation is not counted in progress (no progress chrome)', async ({ page }) => {
+		await navigateToReview(page)
+		await clickByClass(page, 'patient-cards__submit')
+		const hasProgress = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards__progress')
+		})
+		expect(hasProgress).toBe(false)
+	})
+})

--- a/test/e2e/patient-cards-phase3.spec.ts
+++ b/test/e2e/patient-cards-phase3.spec.ts
@@ -1,0 +1,319 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ============================================================
+// Phase 3: per-card validation + cross-card deferred to review
+// ============================================================
+
+async function gotoHarness(page: Page) {
+	await page.goto('/')
+	await page.waitForFunction(() => typeof (window as any).initForm === 'function', { timeout: 10_000 })
+}
+
+async function initPatientCards(page: Page, yaml: string) {
+	return await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'patient-cards' }), yaml)
+}
+
+async function waitForInternal(page: Page) {
+	await page.waitForFunction(
+		() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards')
+		},
+		{ timeout: 15_000 },
+	)
+}
+
+async function clickByClass(page: Page, cls: string) {
+	const ok = await page.evaluate((c: string) => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector(`.${c}`) as HTMLElement | null
+		if (!btn || (btn as HTMLButtonElement).disabled) return false
+		btn.click()
+		return true
+	}, cls)
+	if (!ok) throw new Error(`Button .${cls} not clickable`)
+	await page.waitForTimeout(100)
+}
+
+async function clickByClassEvenIfDisabled(page: Page, cls: string) {
+	await page.evaluate((c: string) => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector(`.${c}`) as HTMLElement | null
+		btn?.click()
+	}, cls)
+	await page.waitForTimeout(100)
+}
+
+async function setStringValue(page: Page, label: string, value: string, language = 'en') {
+	await page.evaluate(
+		({ label, value, language }: { label: string; value: string; language: string }) => {
+			const fvc = (window as any).__currentFvc
+			fvc.setValue(label, language, { content: { [language]: { type: 'string', value } } })
+		},
+		{ label, value, language },
+	)
+	await page.waitForTimeout(250)
+}
+
+async function isContinueDisabled(page: Page): Promise<boolean> {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector('[class*="patient-cards__continue"]') as HTMLButtonElement | null
+		return !!btn && btn.disabled
+	})
+}
+
+async function isSubmitDisabled(page: Page): Promise<boolean> {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector('.patient-cards__submit') as HTMLButtonElement | null
+		return !!btn && btn.disabled
+	})
+}
+
+async function getBlockingFailureCount(page: Page): Promise<number> {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const wrapper = internal?.shadowRoot?.querySelector('.patient-cards')
+		return parseInt(wrapper?.getAttribute('data-blocking-failures') ?? '0', 10)
+	})
+}
+
+async function getReviewFailureCount(page: Page): Promise<number> {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const wrapper = internal?.shadowRoot?.querySelector('.patient-cards')
+		return parseInt(wrapper?.getAttribute('data-review-failures') ?? '0', 10)
+	})
+}
+
+// Wait until validator evaluation finishes for the current view: blocking-failures attribute
+// stabilizes by being read at least once. We use a small idle delay.
+async function waitForValidation(page: Page, ms = 400) {
+	await page.waitForTimeout(ms)
+}
+
+// ============================================================
+// Self-validator blocks Continue
+// ============================================================
+test.describe('Phase 3 / per-card self-validator blocks Continue', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Name
+        type: text-field
+        validators:
+          - validation: |
+              return validate.notBlank(self, 'Name')
+            message: Name is required
+      - field: Q2
+        type: text-field
+`
+
+	test('Continue is disabled while a required self-validator on the current card fails', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await waitForValidation(page)
+		expect(await isContinueDisabled(page)).toBe(true)
+		expect(await getBlockingFailureCount(page)).toBe(1)
+	})
+
+	test('Continue becomes enabled after the required value is provided', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await waitForValidation(page)
+		expect(await isContinueDisabled(page)).toBe(true)
+		await setStringValue(page, 'Name', 'Alice')
+		await waitForValidation(page)
+		expect(await isContinueDisabled(page)).toBe(false)
+		expect(await getBlockingFailureCount(page)).toBe(0)
+	})
+
+	test('Clicking a disabled Continue does NOT advance', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await waitForValidation(page)
+		// Try to click the (disabled) Continue.
+		await clickByClassEvenIfDisabled(page, 'patient-cards__continue')
+		const idx = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return parseInt(internal?.shadowRoot?.querySelector('.patient-cards')?.getAttribute('data-current-card-index') ?? '-1', 10)
+		})
+		expect(idx).toBe(0)
+	})
+})
+
+// ============================================================
+// Cross-card validator: doesn't block per-card, surfaces at review
+// ============================================================
+test.describe('Phase 3 / cross-card validator deferred to review', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: A
+        type: text-field
+        validators:
+          - validation: |
+              return text(self['A']) === text(self['B'])
+            message: A must equal B
+      - field: B
+        type: text-field
+`
+
+	test('cross-card validator does NOT block Continue on the earlier card', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await waitForValidation(page)
+		// Validator on A references B which is on a later card -> classified as cross-card,
+		// so Continue must NOT be disabled by it.
+		expect(await isContinueDisabled(page)).toBe(false)
+		expect(await getBlockingFailureCount(page)).toBe(0)
+	})
+
+	test('a failing cross-card validator surfaces on the review card and blocks Submit', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		// Enter different values on A and B so the cross-card validator fails at review.
+		await setStringValue(page, 'A', 'one')
+		await waitForValidation(page)
+		await clickByClass(page, 'patient-cards__continue')
+		await setStringValue(page, 'B', 'two')
+		await waitForValidation(page)
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		await waitForValidation(page)
+		expect(await getReviewFailureCount(page)).toBeGreaterThanOrEqual(1)
+		expect(await isSubmitDisabled(page)).toBe(true)
+		const errorTexts = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return Array.from(internal?.shadowRoot?.querySelectorAll('.patient-cards__review-errors-message') ?? []).map((e) => (e as HTMLElement).textContent?.trim())
+		})
+		expect(errorTexts).toContain('A must equal B')
+	})
+
+	test('matching cross-card values clear the review failure and re-enable Submit', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await setStringValue(page, 'A', 'same')
+		await waitForValidation(page)
+		await clickByClass(page, 'patient-cards__continue')
+		await setStringValue(page, 'B', 'same')
+		await waitForValidation(page)
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		await waitForValidation(page)
+		expect(await getReviewFailureCount(page)).toBe(0)
+		expect(await isSubmitDisabled(page)).toBe(false)
+	})
+
+	test('review error item Edit button jumps to the source card', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await setStringValue(page, 'A', 'one')
+		await waitForValidation(page)
+		await clickByClass(page, 'patient-cards__continue')
+		await setStringValue(page, 'B', 'two')
+		await waitForValidation(page)
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		await waitForValidation(page)
+		// Click the jump button on the first review error.
+		await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const btn = internal?.shadowRoot?.querySelector('.patient-cards__review-errors-jump') as HTMLElement | null
+			btn?.click()
+		})
+		await page.waitForTimeout(150)
+		const stage = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return internal?.shadowRoot?.querySelector('.patient-cards')?.getAttribute('data-stage') ?? null
+		})
+		expect(stage).toBe('input')
+	})
+})
+
+// ============================================================
+// Mixed: self-validator on later card still blocks navigation on that card
+// ============================================================
+test.describe('Phase 3 / self-validator on later card', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: A
+        type: text-field
+      - field: B
+        type: text-field
+        validators:
+          - validation: |
+              return validate.notBlank(self, 'B')
+            message: B is required
+`
+
+	test('Self-validator on later card does NOT block Continue on the earlier card', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await waitForValidation(page)
+		// We're on card 0 (A). B's validator is attached to B, not A, so blockingFailures = 0.
+		expect(await isContinueDisabled(page)).toBe(false)
+	})
+
+	test('Self-validator blocks Continue when patient reaches the validator-owning card', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await clickByClass(page, 'patient-cards__continue')
+		await waitForValidation(page)
+		expect(await isContinueDisabled(page)).toBe(true)
+	})
+})
+
+// ============================================================
+// All-pass: Submit enabled when nothing fails
+// ============================================================
+test.describe('Phase 3 / all validators passing', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: A
+        type: text-field
+        validators:
+          - validation: |
+              return validate.notBlank(self, 'A')
+            message: A is required
+`
+
+	test('Submit is enabled on review when all validators pass', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await setStringValue(page, 'A', 'value')
+		await waitForValidation(page)
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		await waitForValidation(page)
+		expect(await getReviewFailureCount(page)).toBe(0)
+		expect(await isSubmitDisabled(page)).toBe(false)
+	})
+})

--- a/test/e2e/patient-cards-phase4.spec.ts
+++ b/test/e2e/patient-cards-phase4.spec.ts
@@ -1,0 +1,333 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ============================================================
+// Phase 4: conditional re-evaluation with stay semantics
+// ============================================================
+
+async function gotoHarness(page: Page) {
+	await page.goto('/')
+	await page.waitForFunction(() => typeof (window as any).initForm === 'function', { timeout: 10_000 })
+}
+
+async function initPatientCards(page: Page, yaml: string) {
+	return await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'patient-cards' }), yaml)
+}
+
+async function waitForInternal(page: Page) {
+	await page.waitForFunction(
+		() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards')
+		},
+		{ timeout: 15_000 },
+	)
+}
+
+async function clickByClass(page: Page, cls: string) {
+	const ok = await page.evaluate((c: string) => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector(`.${c}`) as HTMLElement | null
+		if (!btn || (btn as HTMLButtonElement).disabled) return false
+		btn.click()
+		return true
+	}, cls)
+	if (!ok) throw new Error(`Button .${cls} not clickable`)
+	await page.waitForTimeout(150)
+}
+
+async function setStringValue(page: Page, label: string, value: string, language = 'en') {
+	await page.evaluate(
+		({ label, value, language }: { label: string; value: string; language: string }) => {
+			const fvc = (window as any).__currentFvc
+			fvc.setValue(label, language, { content: { [language]: { type: 'string', value } } })
+		},
+		{ label, value, language },
+	)
+	await page.waitForTimeout(300)
+}
+
+async function getCards(page: Page): Promise<{ total: number; currentIdx: number; sectionTitle: string | null }> {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const root = internal?.shadowRoot?.querySelector('.patient-cards')
+		const card = internal?.shadowRoot?.querySelector('.patient-cards__card')
+		return {
+			total: parseInt(root?.getAttribute('data-total-cards') ?? '-1', 10),
+			currentIdx: parseInt(root?.getAttribute('data-current-card-index') ?? '-1', 10),
+			sectionTitle: card?.getAttribute('data-card-section') ?? null,
+		}
+	})
+}
+
+async function getProgressText(page: Page): Promise<string | null> {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		return internal?.shadowRoot?.querySelector('.patient-cards__progress-text')?.textContent?.trim() ?? null
+	})
+}
+
+// ============================================================
+// Field-level computed hidden
+// ============================================================
+test.describe('Phase 4 / Field-level computed hidden', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Trigger
+        type: text-field
+      - field: Conditional
+        type: text-field
+        computedProperties:
+          hidden: |
+            return text(self['Trigger']) !== 'show'
+`
+
+	test('initially conditional is hidden — only Trigger card visible', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(300)
+		const s = await getCards(page)
+		expect(s.total).toBe(1)
+	})
+
+	test('setting Trigger = show reveals Conditional, total cards becomes 2', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(300)
+		expect((await getCards(page)).total).toBe(1)
+		await setStringValue(page, 'Trigger', 'show')
+		await page.waitForTimeout(400)
+		const s = await getCards(page)
+		expect(s.total).toBe(2)
+	})
+
+	test('changing Trigger value back hides Conditional again', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await setStringValue(page, 'Trigger', 'show')
+		await page.waitForTimeout(400)
+		expect((await getCards(page)).total).toBe(2)
+		await setStringValue(page, 'Trigger', 'hide')
+		await page.waitForTimeout(400)
+		expect((await getCards(page)).total).toBe(1)
+	})
+
+	test('progress fraction recomputes after re-flatten', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(300)
+		expect(await getProgressText(page)).toBe('1 / 1')
+		await setStringValue(page, 'Trigger', 'show')
+		await page.waitForTimeout(400)
+		expect(await getProgressText(page)).toBe('1 / 2')
+	})
+})
+
+// ============================================================
+// Group-level computed hidden cascades to children
+// ============================================================
+test.describe('Phase 4 / Group-level computed hidden cascades', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Trigger
+        type: text-field
+      - group: Conditional Group
+        computedProperties:
+          hidden: |
+            return text(self['Trigger']) !== 'show'
+        fields:
+          - field: G1
+            type: text-field
+          - field: G2
+            type: text-field
+`
+
+	test('Group-level hidden cascades to its fields (Trigger only initially)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(300)
+		expect((await getCards(page)).total).toBe(1)
+	})
+
+	test('Group becomes visible when Trigger = show — both fields appear (total 3)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await setStringValue(page, 'Trigger', 'show')
+		await page.waitForTimeout(400)
+		expect((await getCards(page)).total).toBe(3)
+	})
+})
+
+// ============================================================
+// Stay semantics: downstream values preserved across visibility flips
+// ============================================================
+test.describe('Phase 4 / stay semantics on back-edit', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Mode
+        type: text-field
+      - field: Conditional
+        type: text-field
+        computedProperties:
+          hidden: |
+            return text(self['Mode']) !== 'show'
+      - field: AlwaysVisible
+        type: text-field
+`
+
+	test('Hiding a previously-visible card preserves its and downstream container values', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		// Set all values: Mode=show, Conditional=conditional-value, AlwaysVisible=tail-value.
+		await setStringValue(page, 'Mode', 'show')
+		await setStringValue(page, 'Conditional', 'conditional-value')
+		await setStringValue(page, 'AlwaysVisible', 'tail-value')
+		await page.waitForTimeout(400)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(300)
+		expect((await getCards(page)).total).toBe(3)
+
+		// Flip Mode to hide Conditional.
+		await setStringValue(page, 'Mode', 'hide')
+		await page.waitForTimeout(400)
+		expect((await getCards(page)).total).toBe(2)
+
+		// Read container values directly — Conditional and AlwaysVisible values must still be present
+		// even though Conditional is now hidden. Stay semantics: visibility recomputes; data does not.
+		// (Mode may have multiple services since setValue without an id appends; that's irrelevant
+		// to the stay-semantics claim, which is about NOT discarding sibling values on re-flatten.)
+		const presentValues = await page.evaluate(() => {
+			const fvc = (window as any).__currentFvc
+			const labels = ['Conditional', 'AlwaysVisible']
+			const out: Record<string, string[]> = {}
+			for (const label of labels) {
+				const versioned = fvc.getValues((id: string, history: any[]) => (history?.[0]?.value?.label === label ? [history[0].revision] : []))
+				const values: string[] = []
+				for (const versions of Object.values(versioned as any)) {
+					const primitive = (versions as any)?.[0]?.value?.content?.en
+					if (primitive?.value !== undefined) values.push(primitive.value)
+				}
+				out[label] = values
+			}
+			return out
+		})
+		expect(presentValues.Conditional).toContain('conditional-value')
+		expect(presentValues.AlwaysVisible).toContain('tail-value')
+	})
+
+	test('After back-edit reduces visibility, the patient is positioned on a sensible adjacent card', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await setStringValue(page, 'Mode', 'show')
+		await page.waitForTimeout(300)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(300)
+		// Advance to the Conditional card (idx 1).
+		await clickByClass(page, 'patient-cards__continue')
+		await page.waitForTimeout(200)
+		expect((await getCards(page)).currentIdx).toBe(1)
+		// Now hide Conditional by changing Mode. Conditional disappears from the sequence.
+		await setStringValue(page, 'Mode', 'hide')
+		await page.waitForTimeout(500)
+		const s = await getCards(page)
+		// Conditional was at idx 1; with it gone, total=2 and currentIdx clamps to a valid index in [0, 1].
+		expect(s.total).toBe(2)
+		expect(s.currentIdx).toBeGreaterThanOrEqual(0)
+		expect(s.currentIdx).toBeLessThanOrEqual(1)
+	})
+})
+
+// ============================================================
+// Composition: hiddenForPatient AND computed hidden
+// ============================================================
+test.describe('Phase 4 / composition with hiddenForPatient', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: AlwaysVisible
+        type: text-field
+      - field: PatientHidden
+        type: text-field
+        hiddenForPatient: true
+      - field: ConditionallyHidden
+        type: text-field
+        computedProperties:
+          hidden: |
+            return true
+`
+
+	test('Both static hiddenForPatient and computed hidden are honored together (only AlwaysVisible remains)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(400)
+		const cards = await getCards(page)
+		expect(cards.total).toBe(1)
+		expect(cards.sectionTitle).toBe('S')
+	})
+})
+
+// ============================================================
+// Clinician renderer is unaffected by patient-cards computed-hidden behaviour
+// ============================================================
+test.describe('Phase 4 / clinician renderer unchanged', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Trigger
+        type: text-field
+      - field: Conditional
+        type: text-field
+        computedProperties:
+          hidden: |
+            return text(self['Trigger']) !== 'show'
+`
+
+	test('Clinician renderer still respects existing computed hidden semantics (no regression)', async ({ page }) => {
+		await gotoHarness(page)
+		await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'form' }), yaml)
+		await page.waitForFunction(
+			() => {
+				const el = document.querySelector('icure-form')
+				return !!el?.shadowRoot?.querySelector('.icure-form')
+			},
+			{ timeout: 15_000 },
+		)
+		await page.waitForTimeout(500)
+		const labels = await page.evaluate(() => {
+			const root = document.querySelector('icure-form')?.shadowRoot
+			if (!root) return []
+			return Array.from(root.querySelectorAll('.icure-form-field')).map((el) => (el as any).label)
+		})
+		// Conditional is hidden initially because Trigger has no value.
+		expect(labels).toContain('Trigger')
+		expect(labels).not.toContain('Conditional')
+	})
+})

--- a/test/e2e/patient-cards-phase5.spec.ts
+++ b/test/e2e/patient-cards-phase5.spec.ts
@@ -1,0 +1,277 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ============================================================
+// Phase 5: auto fast-forward resume
+// ============================================================
+
+async function gotoHarness(page: Page) {
+	await page.goto('/')
+	await page.waitForFunction(() => typeof (window as any).initForm === 'function', { timeout: 10_000 })
+}
+
+async function initPatientCardsWithPrefill(page: Page, yaml: string, prefill: Array<{ label: string; value: string }>) {
+	return await page.evaluate(
+		async ({ yaml, prefill }: { yaml: string; prefill: any[] }) =>
+			(window as any).initForm({ yaml, language: 'en', renderer: 'patient-cards', prefill }),
+		{ yaml, prefill },
+	)
+}
+
+async function initPatientCardsEmpty(page: Page, yaml: string) {
+	return await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'patient-cards' }), yaml)
+}
+
+async function waitForInternal(page: Page) {
+	await page.waitForFunction(
+		() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards')
+		},
+		{ timeout: 15_000 },
+	)
+}
+
+async function getStageAndIndex(page: Page) {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const wrapper = internal?.shadowRoot?.querySelector('.patient-cards')
+		return {
+			stage: wrapper?.getAttribute('data-stage') ?? null,
+			currentCardIndex: parseInt(wrapper?.getAttribute('data-current-card-index') ?? '-1', 10),
+			totalCards: parseInt(wrapper?.getAttribute('data-total-cards') ?? '-1', 10),
+		}
+	})
+}
+
+// Wait for the async reflatten + fast-forward pass to settle.
+async function waitForFastForward(page: Page) {
+	await page.waitForTimeout(500)
+}
+
+// ============================================================
+// Empty container -> welcome (no fast-forward)
+// ============================================================
+test.describe('Phase 5 / empty container stays on welcome', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+      - field: Q2
+        type: text-field
+`
+
+	test('first-time use: stage remains "welcome"', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCardsEmpty(page, yaml)
+		await waitForInternal(page)
+		await waitForFastForward(page)
+		expect((await getStageAndIndex(page)).stage).toBe('welcome')
+	})
+})
+
+// ============================================================
+// Partial fill -> first unanswered card
+// ============================================================
+test.describe('Phase 5 / partial fill jumps to first unanswered card', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+      - field: Q2
+        type: text-field
+      - field: Q3
+        type: text-field
+`
+
+	test('with only Q1 filled, fast-forward lands on Q2 (idx 1)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCardsWithPrefill(page, yaml, [{ label: 'Q1', value: 'one' }])
+		await waitForInternal(page)
+		await waitForFastForward(page)
+		const s = await getStageAndIndex(page)
+		expect(s.stage).toBe('input')
+		expect(s.currentCardIndex).toBe(1)
+	})
+
+	test('with Q1 and Q2 filled, fast-forward lands on Q3 (idx 2)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCardsWithPrefill(page, yaml, [
+			{ label: 'Q1', value: 'one' },
+			{ label: 'Q2', value: 'two' },
+		])
+		await waitForInternal(page)
+		await waitForFastForward(page)
+		const s = await getStageAndIndex(page)
+		expect(s.stage).toBe('input')
+		expect(s.currentCardIndex).toBe(2)
+	})
+
+	test('with Q1 filled but Q2 missing in the middle, fast-forward stops at Q2 (idx 1) — order preserved', async ({ page }) => {
+		await gotoHarness(page)
+		// Q1 and Q3 filled; Q2 missing.
+		await initPatientCardsWithPrefill(page, yaml, [
+			{ label: 'Q1', value: 'one' },
+			{ label: 'Q3', value: 'three' },
+		])
+		await waitForInternal(page)
+		await waitForFastForward(page)
+		const s = await getStageAndIndex(page)
+		expect(s.stage).toBe('input')
+		expect(s.currentCardIndex).toBe(1)
+	})
+})
+
+// ============================================================
+// All filled -> straight to review
+// ============================================================
+test.describe('Phase 5 / fully completed forms land at review', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+      - field: Q2
+        type: text-field
+`
+
+	test('with all fields filled, fast-forward lands at the review stage', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCardsWithPrefill(page, yaml, [
+			{ label: 'Q1', value: 'one' },
+			{ label: 'Q2', value: 'two' },
+		])
+		await waitForInternal(page)
+		await waitForFastForward(page)
+		expect((await getStageAndIndex(page)).stage).toBe('review')
+	})
+})
+
+// ============================================================
+// Validators interact with fast-forward
+// ============================================================
+test.describe('Phase 5 / fast-forward stops at the first invalid card', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+        validators:
+          - validation: |
+              return text(self['Q1'])?.length >= 3
+            message: Q1 must be at least 3 characters
+      - field: Q2
+        type: text-field
+`
+
+	test('a previously-answered field whose validator now fails halts fast-forward at that card', async ({ page }) => {
+		await gotoHarness(page)
+		// Q1 was filled with a short value that fails the >=3 chars validator. Q2 has a value too.
+		await initPatientCardsWithPrefill(page, yaml, [
+			{ label: 'Q1', value: 'ab' },
+			{ label: 'Q2', value: 'two' },
+		])
+		await waitForInternal(page)
+		await waitForFastForward(page)
+		const s = await getStageAndIndex(page)
+		expect(s.stage).toBe('input')
+		expect(s.currentCardIndex).toBe(0)
+	})
+
+	test('validators that pass do not halt fast-forward', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCardsWithPrefill(page, yaml, [
+			{ label: 'Q1', value: 'longenough' },
+			{ label: 'Q2', value: 'two' },
+		])
+		await waitForInternal(page)
+		await waitForFastForward(page)
+		expect((await getStageAndIndex(page)).stage).toBe('review')
+	})
+})
+
+// ============================================================
+// Fast-forward respects conditional re-evaluation (Phase 4 composition)
+// ============================================================
+test.describe('Phase 5 / fast-forward composes with conditional hiding', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Mode
+        type: text-field
+      - field: Conditional
+        type: text-field
+        computedProperties:
+          hidden: |
+            return text(self['Mode']) !== 'show'
+      - field: Tail
+        type: text-field
+`
+
+	test('with Mode=hide and Tail filled but Conditional empty, fast-forward sees 2 cards and lands at review', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCardsWithPrefill(page, yaml, [
+			{ label: 'Mode', value: 'hide' },
+			{ label: 'Tail', value: 'tail-value' },
+		])
+		await waitForInternal(page)
+		await waitForFastForward(page)
+		// Conditional is hidden (Mode != show), so total cards = 2 and both are filled => review.
+		const s = await getStageAndIndex(page)
+		expect(s.stage).toBe('review')
+		expect(s.totalCards).toBe(2)
+	})
+})
+
+// ============================================================
+// Fast-forward runs at most once
+// ============================================================
+test.describe('Phase 5 / fast-forward is one-shot', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+      - field: Q2
+        type: text-field
+`
+
+	test('navigating back to welcome does NOT re-trigger fast-forward', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCardsWithPrefill(page, yaml, [{ label: 'Q1', value: 'one' }])
+		await waitForInternal(page)
+		await waitForFastForward(page)
+		// Initially fast-forwarded to Q2 (idx 1).
+		expect((await getStageAndIndex(page)).currentCardIndex).toBe(1)
+		// Press Back to go back to Q1.
+		await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const btn = internal?.shadowRoot?.querySelector('.patient-cards__back') as HTMLElement | null
+			btn?.click()
+		})
+		await page.waitForTimeout(200)
+		expect((await getStageAndIndex(page)).currentCardIndex).toBe(0)
+		// Press Back again to go to welcome.
+		await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const btn = internal?.shadowRoot?.querySelector('.patient-cards__back') as HTMLElement | null
+			btn?.click()
+		})
+		await page.waitForTimeout(300)
+		// Stage is welcome and stays there — fast-forward must not re-fire.
+		expect((await getStageAndIndex(page)).stage).toBe('welcome')
+	})
+})

--- a/test/e2e/patient-cards-phase6.spec.ts
+++ b/test/e2e/patient-cards-phase6.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ============================================================
+// Phase 6: i18n patient-renderer chrome translation keys
+// ============================================================
+
+async function gotoHarness(page: Page) {
+	await page.goto('/')
+	await page.waitForFunction(() => typeof (window as any).initForm === 'function', { timeout: 10_000 })
+}
+
+async function waitForInternal(page: Page) {
+	await page.waitForFunction(
+		() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards')
+		},
+		{ timeout: 15_000 },
+	)
+}
+
+async function clickByClass(page: Page, cls: string) {
+	const ok = await page.evaluate((c: string) => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector(`.${c}`) as HTMLElement | null
+		if (!btn || (btn as HTMLButtonElement).disabled) return false
+		btn.click()
+		return true
+	}, cls)
+	if (!ok) throw new Error(`Button .${cls} not clickable`)
+	await page.waitForTimeout(150)
+}
+
+async function readChromeStrings(page: Page) {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const root = internal?.shadowRoot
+		return {
+			start: root?.querySelector('.patient-cards__start')?.textContent?.trim() ?? null,
+			continue: root?.querySelector('[class*="patient-cards__continue"]')?.textContent?.trim() ?? null,
+			back: root?.querySelector('.patient-cards__back')?.textContent?.trim() ?? null,
+			submit: root?.querySelector('.patient-cards__submit')?.textContent?.trim() ?? null,
+			progress: root?.querySelector('.patient-cards__progress-text')?.textContent?.trim() ?? null,
+			reviewHeading: root?.querySelector('.patient-cards__review-heading')?.textContent?.trim() ?? null,
+			reviewEdit: root?.querySelector('.patient-cards__review-edit')?.textContent?.trim() ?? null,
+			confirmationHeading: root?.querySelector('.patient-cards__confirmation-heading')?.textContent?.trim() ?? null,
+			confirmationBody: root?.querySelector('.patient-cards__confirmation-body')?.textContent?.trim() ?? null,
+		}
+	})
+}
+
+const simpleYaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+`
+
+// ============================================================
+// English defaults when no provider / no translation
+// ============================================================
+test.describe('Phase 6 / English defaults', () => {
+	test('without a translationProvider, English defaults render', async ({ page }) => {
+		await gotoHarness(page)
+		await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'patient-cards' }), simpleYaml)
+		await waitForInternal(page)
+		const chrome = await readChromeStrings(page)
+		expect(chrome.start).toBe('Start')
+		await clickByClass(page, 'patient-cards__start')
+		const inputChrome = await readChromeStrings(page)
+		expect(inputChrome.continue).toBe('Continue')
+		// On the first input card Back returns to welcome (Phase 2). The Back button exists.
+		expect(inputChrome.back).toBe('Back')
+		expect(inputChrome.progress).toBe('1 / 1')
+	})
+})
+
+// ============================================================
+// translationProvider returning translated chrome strings
+// ============================================================
+test.describe('Phase 6 / translationProvider supplies chrome translations', () => {
+	test('French translations replace defaults at every stage', async ({ page }) => {
+		await gotoHarness(page)
+		// initForm doesn't take a translationProvider directly. We use the Form translations field instead.
+		const yaml = `
+form: F
+translations:
+  - language: fr
+    translations:
+      patient-renderer.start: Commencer
+      patient-renderer.continue: Continuer
+      patient-renderer.back: Retour
+      patient-renderer.submit: Envoyer
+      patient-renderer.progress: Question {current} sur {total}
+      patient-renderer.review-heading: Vérifiez vos réponses
+      patient-renderer.review-edit: Modifier
+      patient-renderer.review-empty: vide
+      patient-renderer.review-errors-title: Veuillez corriger avant d'envoyer
+      patient-renderer.confirmation-heading: Merci
+      patient-renderer.confirmation-body: Vos réponses ont été envoyées.
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+`
+		await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'fr', renderer: 'patient-cards' }), yaml)
+		await waitForInternal(page)
+		// Welcome
+		expect((await readChromeStrings(page)).start).toBe('Commencer')
+		// Input
+		await clickByClass(page, 'patient-cards__start')
+		let chrome = await readChromeStrings(page)
+		expect(chrome.continue).toBe('Continuer')
+		expect(chrome.back).toBe('Retour')
+		expect(chrome.progress).toBe('Question 1 sur 1')
+		// Continue (single card -> review)
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		chrome = await readChromeStrings(page)
+		expect(chrome.reviewHeading).toBe('Vérifiez vos réponses')
+		expect(chrome.reviewEdit).toBe('Modifier')
+		expect(chrome.submit).toBe('Envoyer')
+		// Submit -> confirmation
+		await clickByClass(page, 'patient-cards__submit')
+		chrome = await readChromeStrings(page)
+		expect(chrome.confirmationHeading).toBe('Merci')
+		expect(chrome.confirmationBody).toBe('Vos réponses ont été envoyées.')
+	})
+})
+
+// ============================================================
+// Partial translations: only some keys translated, others fall back
+// ============================================================
+test.describe('Phase 6 / partial translations fall back per-key', () => {
+	test('keys with no translation fall back to English defaults', async ({ page }) => {
+		await gotoHarness(page)
+		const yaml = `
+form: F
+translations:
+  - language: fr
+    translations:
+      patient-renderer.start: Commencer
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+`
+		await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'fr', renderer: 'patient-cards' }), yaml)
+		await waitForInternal(page)
+		expect((await readChromeStrings(page)).start).toBe('Commencer')
+		await clickByClass(page, 'patient-cards__start')
+		const chrome = await readChromeStrings(page)
+		// No translation registered for continue/back/progress — fall back to English defaults.
+		expect(chrome.continue).toBe('Continue')
+		expect(chrome.back).toBe('Back')
+		expect(chrome.progress).toBe('1 / 1')
+	})
+})
+
+// ============================================================
+// Substitution tokens in progress key
+// ============================================================
+test.describe('Phase 6 / progress substitutions', () => {
+	test('progress translation can re-order tokens via {current} / {total}', async ({ page }) => {
+		await gotoHarness(page)
+		const yaml = `
+form: F
+translations:
+  - language: nl
+    translations:
+      patient-renderer.progress: Vraag {current} van {total}
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+      - field: Q2
+        type: text-field
+`
+		await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'nl', renderer: 'patient-cards' }), yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const chrome = await readChromeStrings(page)
+		expect(chrome.progress).toBe('Vraag 1 van 2')
+	})
+})
+
+// ============================================================
+// `translate` flag on Group/Field still respected (no regression)
+// ============================================================
+test.describe('Phase 6 / existing translate flag continues to work', () => {
+	test('Field labels are still translated via translationProvider when translate=true', async ({ page }) => {
+		await gotoHarness(page)
+		const yaml = `
+form: F
+translations:
+  - language: nl
+    translations:
+      Q1: Eerste vraag
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+`
+		await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'nl', renderer: 'patient-cards' }), yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		// Field label is translated on the input card via the underlying field component.
+		// The review card should also use the translation for the field's display label.
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		const reviewLabels = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return Array.from(internal?.shadowRoot?.querySelectorAll('.patient-cards__review-label') ?? []).map((el) => (el as HTMLElement).textContent?.trim())
+		})
+		expect(reviewLabels).toContain('Eerste vraag')
+	})
+})

--- a/test/e2e/patient-cards-phase7.spec.ts
+++ b/test/e2e/patient-cards-phase7.spec.ts
@@ -1,0 +1,430 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ============================================================
+// Phase 7: field-type coverage + questionsPerCard=2
+// ============================================================
+
+async function gotoHarness(page: Page) {
+	await page.goto('/')
+	await page.waitForFunction(() => typeof (window as any).initForm === 'function', { timeout: 10_000 })
+}
+
+async function initPatientCards(page: Page, yaml: string, questionsPerCard?: number) {
+	return await page.evaluate(
+		async ({ yaml, k }: { yaml: string; k?: number }) => (window as any).initForm({ yaml, language: 'en', renderer: 'patient-cards', questionsPerCard: k }),
+		{ yaml, k: questionsPerCard },
+	)
+}
+
+async function waitForInternal(page: Page) {
+	await page.waitForFunction(
+		() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards')
+		},
+		{ timeout: 15_000 },
+	)
+}
+
+async function clickByClass(page: Page, cls: string) {
+	const ok = await page.evaluate((c: string) => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector(`.${c}`) as HTMLElement | null
+		if (!btn || (btn as HTMLButtonElement).disabled) return false
+		btn.click()
+		return true
+	}, cls)
+	if (!ok) throw new Error(`Button .${cls} not clickable`)
+	await page.waitForTimeout(150)
+}
+
+async function getCardInfo(page: Page) {
+	return await page.evaluate(() => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const root = internal?.shadowRoot
+		const wrapper = root?.querySelector('.patient-cards')
+		const body = root?.querySelector('.patient-cards__card-body')
+		const interactiveTags = ['icure-form-text-field', 'icure-form-number-field', 'icure-form-measure-field', 'icure-form-token-field', 'icure-form-items-list-field', 'icure-form-date-picker', 'icure-form-time-picker', 'icure-form-date-time-picker', 'icure-form-dropdown-field', 'icure-form-radio-button', 'icure-form-checkbox']
+		const interactiveCount = interactiveTags.reduce((acc, tag) => acc + (body?.querySelectorAll(tag).length ?? 0), 0)
+		const labels = body?.querySelectorAll('icure-form-label').length ?? 0
+		const fieldTagsInOrder = Array.from(body?.children ?? []).map((c) => (c as HTMLElement).tagName.toLowerCase())
+		return {
+			total: parseInt(wrapper?.getAttribute('data-total-cards') ?? '-1', 10),
+			currentIdx: parseInt(wrapper?.getAttribute('data-current-card-index') ?? '-1', 10),
+			interactiveCount,
+			labelCount: labels,
+			fieldTagsInOrder,
+		}
+	})
+}
+
+// ============================================================
+// Field-type coverage — each standard type renders
+// ============================================================
+test.describe('Phase 7 / field-type coverage', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: t1
+        type: text-field
+      - field: m1
+        type: measure-field
+      - field: n1
+        type: number-field
+      - field: dp1
+        type: date-picker
+      - field: tp1
+        type: time-picker
+      - field: dtp1
+        type: date-time-picker
+      - field: dd1
+        type: dropdown
+      - field: rb1
+        type: radio-button
+      - field: cb1
+        type: checkbox
+      - field: tk1
+        type: token-field
+      - field: il1
+        type: items-list-field
+`
+
+	test('all standard interactive types render against fixture form', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const expected = [
+			'icure-form-text-field',
+			'icure-form-measure-field',
+			'icure-form-number-field',
+			'icure-form-date-picker',
+			'icure-form-time-picker',
+			'icure-form-date-time-picker',
+			'icure-form-dropdown-field',
+			'icure-form-radio-button',
+			'icure-form-checkbox',
+			'icure-form-token-field',
+			'icure-form-items-list-field',
+		]
+		// One card per field at default k=1: walk through each card and collect tag of the rendered field.
+		const seen: string[] = []
+		for (let i = 0; i < expected.length; i++) {
+			const info = await getCardInfo(page)
+			seen.push(info.fieldTagsInOrder[0])
+			if (i < expected.length - 1) {
+				await clickByClass(page, 'patient-cards__continue')
+			}
+		}
+		expect(seen).toEqual(expected)
+	})
+})
+
+// ============================================================
+// questionsPerCard chunking
+// ============================================================
+test.describe('Phase 7 / questionsPerCard chunking', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: a
+        type: text-field
+      - field: b
+        type: text-field
+      - field: c
+        type: text-field
+      - field: d
+        type: text-field
+      - field: e
+        type: text-field
+`
+
+	test('k=1 (default) yields one card per field', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		expect((await getCardInfo(page)).total).toBe(5)
+	})
+
+	test('k=2 produces ceil(5/2)=3 cards with up to 2 interactive fields each', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml, 2)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const c1 = await getCardInfo(page)
+		expect(c1.total).toBe(3)
+		expect(c1.interactiveCount).toBeLessThanOrEqual(2)
+		expect(c1.interactiveCount).toBe(2)
+		await clickByClass(page, 'patient-cards__continue')
+		const c2 = await getCardInfo(page)
+		expect(c2.interactiveCount).toBe(2)
+		await clickByClass(page, 'patient-cards__continue')
+		const c3 = await getCardInfo(page)
+		expect(c3.interactiveCount).toBe(1)
+	})
+
+	test('k values out of range clamp to 1..2 (k=5 -> 2, k=0 -> 1)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml, 5)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		expect((await getCardInfo(page)).total).toBe(3) // same as k=2
+	})
+})
+
+// ============================================================
+// Label fields are zero-count and attach to surrounding card
+// ============================================================
+test.describe('Phase 7 / Label fields', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: instruction
+        type: label
+      - field: a
+        type: text-field
+      - field: b
+        type: text-field
+`
+
+	test('Label is rendered inside the same card as the next interactive field; total cards = 2', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const info = await getCardInfo(page)
+		expect(info.total).toBe(2)
+		expect(info.interactiveCount).toBe(1)
+		expect(info.labelCount).toBe(1)
+		// The Label appears before the interactive field on the same card.
+		expect(info.fieldTagsInOrder).toEqual(['icure-form-label', 'icure-form-text-field'])
+	})
+
+	test('Label does not consume the questionsPerCard=2 slot — card carries both interactive fields', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml, 2)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const info = await getCardInfo(page)
+		expect(info.total).toBe(1)
+		expect(info.interactiveCount).toBe(2)
+		expect(info.labelCount).toBe(1)
+	})
+})
+
+// ============================================================
+// Button (action) fields are skipped with console.warn
+// ============================================================
+test.describe('Phase 7 / Button fields skipped + warned', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: notes
+        type: text-field
+      - field: do-something
+        type: action
+`
+
+	test('Button is excluded from card sequence and a warning is logged', async ({ page }) => {
+		await gotoHarness(page)
+		// Capture console messages.
+		const warnings: string[] = []
+		page.on('console', (msg) => {
+			if (msg.type() === 'warning' || msg.type() === 'warn') warnings.push(msg.text())
+		})
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const info = await getCardInfo(page)
+		expect(info.total).toBe(1)
+		expect(info.fieldTagsInOrder).toEqual(['icure-form-text-field'])
+		// Allow a beat for warns to flush.
+		await page.waitForTimeout(100)
+		const matched = warnings.some((w) => w.toLowerCase().includes('button') || w.toLowerCase().includes('action'))
+		expect(matched).toBe(true)
+	})
+})
+
+// ============================================================
+// Readonly fields are zero-count toward questionsPerCard
+// ============================================================
+test.describe('Phase 7 / readonly fields', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: ro
+        type: text-field
+        readonly: true
+      - field: a
+        type: text-field
+      - field: b
+        type: text-field
+`
+
+	test('readonly Field does not count toward questionsPerCard (k=2 fits ro + a + b)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml, 2)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const info = await getCardInfo(page)
+		// ro=zero-count, a + b = 2 interactive -> 1 card.
+		expect(info.total).toBe(1)
+	})
+
+	test('readonly Field still renders in the card body (visible content)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		// k=1: card 0 carries the readonly attached to the next interactive (a).
+		const info = await getCardInfo(page)
+		expect(info.fieldTagsInOrder.length).toBeGreaterThanOrEqual(2)
+		// readonly text-field still appears (it's a text-field that's readonly).
+		expect(info.fieldTagsInOrder.filter((t) => t === 'icure-form-text-field').length).toBeGreaterThanOrEqual(2)
+	})
+})
+
+// ============================================================
+// `standalone` Field flag forces own card
+// ============================================================
+test.describe('Phase 7 / standalone Field flag', () => {
+	test('a standalone interactive Field gets its own card even at k=2', async ({ page }) => {
+		const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: a
+        type: text-field
+      - field: b
+        type: text-field
+        standalone: true
+      - field: c
+        type: text-field
+      - field: d
+        type: text-field
+`
+		await gotoHarness(page)
+		await initPatientCards(page, yaml, 2)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		// Expect: [a] then [b alone] then [c, d] = 3 cards
+		const c1 = await getCardInfo(page)
+		expect(c1.total).toBe(3)
+		expect(c1.interactiveCount).toBe(1)
+		await clickByClass(page, 'patient-cards__continue')
+		const c2 = await getCardInfo(page)
+		expect(c2.interactiveCount).toBe(1)
+		await clickByClass(page, 'patient-cards__continue')
+		const c3 = await getCardInfo(page)
+		expect(c3.interactiveCount).toBe(2)
+	})
+
+	test('a standalone Label appears alone on its own card', async ({ page }) => {
+		const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: instruction
+        type: label
+        standalone: true
+      - field: a
+        type: text-field
+      - field: b
+        type: text-field
+`
+		await gotoHarness(page)
+		await initPatientCards(page, yaml, 2)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		// Card 1: [label] alone, Card 2: [a, b]
+		const c1 = await getCardInfo(page)
+		expect(c1.total).toBe(2)
+		expect(c1.interactiveCount).toBe(0)
+		expect(c1.labelCount).toBe(1)
+		await clickByClass(page, 'patient-cards__continue')
+		const c2 = await getCardInfo(page)
+		expect(c2.interactiveCount).toBe(2)
+		expect(c2.labelCount).toBe(0)
+	})
+
+	test('multiple standalone fields each get their own card', async ({ page }) => {
+		const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: a
+        type: text-field
+        standalone: true
+      - field: b
+        type: text-field
+        standalone: true
+      - field: c
+        type: text-field
+        standalone: true
+`
+		await gotoHarness(page)
+		await initPatientCards(page, yaml, 2)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		expect((await getCardInfo(page)).total).toBe(3)
+	})
+
+	test('standalone round-trips through Form.parse / toJson', async ({ page }) => {
+		await gotoHarness(page)
+		const out = await page.evaluate(() =>
+			(window as any).formToJson({
+				form: 'RT',
+				sections: [
+					{
+						section: 'S',
+						fields: [{ field: 'A', type: 'text-field', standalone: true }],
+					},
+				],
+			}),
+		)
+		expect(out.sections[0].fields[0].standalone).toBe(true)
+	})
+})
+
+// ============================================================
+// Section / Group boundaries force a new card even mid-chunk
+// ============================================================
+test.describe('Phase 7 / section and group boundaries flush chunks', () => {
+	const yaml = `
+form: F
+sections:
+  - section: S1
+    fields:
+      - field: a
+        type: text-field
+  - section: S2
+    fields:
+      - field: b
+        type: text-field
+      - field: c
+        type: text-field
+`
+
+	test('with k=2, S1 ends after 1 field even though there was room; S2 produces its own cards', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, yaml, 2)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		// k=2 but section boundary forces: card1=[a], card2=[b,c]
+		expect((await getCardInfo(page)).total).toBe(2)
+	})
+})

--- a/test/e2e/patient-cards-phase8.spec.ts
+++ b/test/e2e/patient-cards-phase8.spec.ts
@@ -1,0 +1,363 @@
+import { test, expect, Page } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+// ============================================================
+// Phase 8: theme + animations + accessibility
+// ============================================================
+
+async function gotoHarness(page: Page) {
+	await page.goto('/')
+	await page.waitForFunction(() => typeof (window as any).initForm === 'function', { timeout: 10_000 })
+}
+
+async function initPatientCards(page: Page, yaml: string) {
+	return await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'patient-cards' }), yaml)
+}
+
+async function waitForInternal(page: Page) {
+	await page.waitForFunction(
+		() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards')
+		},
+		{ timeout: 15_000 },
+	)
+}
+
+async function clickByClass(page: Page, cls: string) {
+	const ok = await page.evaluate((c: string) => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector(`.${c}`) as HTMLElement | null
+		if (!btn || (btn as HTMLButtonElement).disabled) return false
+		btn.click()
+		return true
+	}, cls)
+	if (!ok) throw new Error(`Button .${cls} not clickable`)
+	await page.waitForTimeout(150)
+}
+
+const sampleYaml = `
+form: F
+description: D
+sections:
+  - section: S
+    fields:
+      - field: Q1
+        type: text-field
+      - field: Q2
+        type: text-field
+`
+
+// ============================================================
+// ARIA & semantic roles
+// ============================================================
+test.describe('Phase 8 / ARIA semantics', () => {
+	test('progress bar has role="progressbar" with aria attributes', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const attrs = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const pb = internal?.shadowRoot?.querySelector('.patient-cards__progress') as HTMLElement | null
+			return {
+				role: pb?.getAttribute('role'),
+				min: pb?.getAttribute('aria-valuemin'),
+				max: pb?.getAttribute('aria-valuemax'),
+				now: pb?.getAttribute('aria-valuenow'),
+				label: pb?.getAttribute('aria-label'),
+			}
+		})
+		expect(attrs.role).toBe('progressbar')
+		expect(attrs.min).toBe('1')
+		expect(attrs.max).toBe('2')
+		expect(attrs.now).toBe('1')
+		expect(attrs.label).toBe('1 / 2')
+	})
+
+	test('progress text has aria-live="polite" for screen-reader announcements', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const live = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return internal?.shadowRoot?.querySelector('.patient-cards__progress-text')?.getAttribute('aria-live')
+		})
+		expect(live).toBe('polite')
+	})
+
+	test('validation error banner has role="alert"', async ({ page }) => {
+		await gotoHarness(page)
+		// Cross-card validator: A's validator references B (on a later card). At A's card the
+		// validator is deferred to review; at review with mismatched values it fails and the
+		// error banner appears with role="alert".
+		const yaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: A
+        type: text-field
+        validators:
+          - validation: |
+              return text(self['A']) === text(self['B'])
+            message: A must equal B
+      - field: B
+        type: text-field
+`
+		await initPatientCards(page, yaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.evaluate(() => {
+			const fvc = (window as any).__currentFvc
+			fvc.setValue('A', 'en', { content: { en: { type: 'string', value: 'one' } } })
+		})
+		await page.waitForTimeout(300)
+		await clickByClass(page, 'patient-cards__continue')
+		await page.evaluate(() => {
+			const fvc = (window as any).__currentFvc
+			fvc.setValue('B', 'en', { content: { en: { type: 'string', value: 'two' } } })
+		})
+		await page.waitForTimeout(300)
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		// Wait for async review validator evaluation to complete (banner appears).
+		await page.waitForFunction(
+			() => {
+				const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+				return !!internal?.shadowRoot?.querySelector('.patient-cards__review-errors')
+			},
+			{ timeout: 5_000 },
+		)
+		const role = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return internal?.shadowRoot?.querySelector('.patient-cards__review-errors')?.getAttribute('role')
+		})
+		expect(role).toBe('alert')
+	})
+})
+
+// ============================================================
+// Focus management
+// ============================================================
+test.describe('Phase 8 / focus management', () => {
+	test('Start button receives focus on welcome stage', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		await page.waitForTimeout(200)
+		const focusedTag = await page.evaluate(() => {
+			// Find deep active element across shadow boundaries.
+			let active: Element | null = document.activeElement
+			while (active && (active as any).shadowRoot && (active as any).shadowRoot.activeElement) {
+				active = (active as any).shadowRoot.activeElement
+			}
+			return active?.className ?? null
+		})
+		expect(focusedTag).toContain('patient-cards__start')
+	})
+
+	test('Focus moves to Continue / interactive field on entering input stage', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(300)
+		const focusInfo = await page.evaluate(() => {
+			let active: Element | null = document.activeElement
+			while (active && (active as any).shadowRoot && (active as any).shadowRoot.activeElement) {
+				active = (active as any).shadowRoot.activeElement
+			}
+			return {
+				className: (active as HTMLElement | null)?.className ?? null,
+				tagName: active?.tagName.toLowerCase() ?? null,
+				editable: (active as HTMLElement | null)?.isContentEditable ?? false,
+			}
+		})
+		// Either an editable element inside the field, or the Continue button as fallback if no editable was found.
+		const looksGood = !!(focusInfo.editable || focusInfo.className?.includes('patient-cards__continue') || focusInfo.tagName === 'input' || focusInfo.tagName === 'textarea')
+		expect(looksGood).toBe(true)
+	})
+})
+
+// ============================================================
+// Touch targets
+// ============================================================
+test.describe('Phase 8 / touch targets', () => {
+	test('primary buttons render with min height/width ≥ 44px', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		const sizes = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const btn = internal?.shadowRoot?.querySelector('.patient-cards__start') as HTMLElement
+			if (!btn) return null
+			const rect = btn.getBoundingClientRect()
+			return { width: rect.width, height: rect.height }
+		})
+		expect(sizes).not.toBeNull()
+		expect(sizes!.height).toBeGreaterThanOrEqual(44)
+		expect(sizes!.width).toBeGreaterThanOrEqual(44)
+	})
+})
+
+// ============================================================
+// Mobile responsiveness at 360px
+// ============================================================
+test.describe('Phase 8 / responsive at 360px', () => {
+	test.use({ viewport: { width: 360, height: 640 } })
+
+	test('renderer is usable at 360px width without horizontal overflow', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		const overflow = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const card = internal?.shadowRoot?.querySelector('.patient-cards') as HTMLElement
+			if (!card) return null
+			const rect = card.getBoundingClientRect()
+			return { width: rect.width, viewportWidth: window.innerWidth }
+		})
+		expect(overflow).not.toBeNull()
+		expect(overflow!.width).toBeLessThanOrEqual(overflow!.viewportWidth)
+	})
+
+	test('Start button remains tap-target-sized at 360px', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		const sizes = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const btn = internal?.shadowRoot?.querySelector('.patient-cards__start') as HTMLElement
+			const rect = btn?.getBoundingClientRect()
+			return rect ? { width: rect.width, height: rect.height } : null
+		})
+		expect(sizes!.height).toBeGreaterThanOrEqual(44)
+		expect(sizes!.width).toBeGreaterThanOrEqual(44)
+	})
+})
+
+// ============================================================
+// Theme CSS custom properties exposed
+// ============================================================
+test.describe('Phase 8 / theming hooks', () => {
+	test('CSS custom properties are exposed on the internal element for host override', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		// Apply a host-side override and check the accent color propagates.
+		await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as HTMLElement | null
+			if (internal) internal.style.setProperty('--patient-cards-accent', 'rgb(255, 0, 128)')
+		})
+		await page.waitForTimeout(100)
+		const accent = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const bar = internal?.shadowRoot?.querySelector('.patient-cards__progress-bar') as HTMLElement
+			return bar ? getComputedStyle(bar).backgroundColor : null
+		})
+		// Welcome stage doesn't render the progress bar — first navigate to input.
+		await clickByClass(page, 'patient-cards__start')
+		const accentAfter = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const bar = internal?.shadowRoot?.querySelector('.patient-cards__progress-bar') as HTMLElement
+			return bar ? getComputedStyle(bar).backgroundColor : null
+		})
+		expect(accentAfter).toBe('rgb(255, 0, 128)')
+	})
+})
+
+// ============================================================
+// Keyboard navigation
+// ============================================================
+test.describe('Phase 8 / keyboard navigation', () => {
+	test('Start button can be activated with Enter via keyboard', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		await page.waitForTimeout(200)
+		// Focus is already on Start from updated() lifecycle.
+		await page.keyboard.press('Enter')
+		await page.waitForTimeout(200)
+		const stage = await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return internal?.shadowRoot?.querySelector('.patient-cards')?.getAttribute('data-stage') ?? null
+		})
+		expect(stage).toBe('input')
+	})
+})
+
+// ============================================================
+// axe-core WCAG 2.1 AA scan
+// ============================================================
+test.describe('Phase 8 / axe-core a11y scan', () => {
+	// Helper: scan and filter violations originating in the patient-cards markup (not the harness page
+	// and not embedded field components like icure-form-text-field which we don't ship the styles for).
+	async function patientCardsViolations(page: Page) {
+		// Let animations finish so opacity-tweening doesn't trip color-contrast checks.
+		await page.waitForTimeout(600)
+		const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze()
+		return results.violations.filter((v) =>
+			v.nodes.some((n) => {
+				const html = n.html ?? ''
+				const target = (n.target ?? []).join(' ')
+				const inPatient = html.includes('patient-cards') || target.includes('patient-cards')
+				const inFieldComponent =
+					html.startsWith('<icure-form-text-field') ||
+					html.startsWith('<icure-form-measure-field') ||
+					html.startsWith('<icure-form-number-field') ||
+					html.startsWith('<icure-form-token-field') ||
+					html.startsWith('<icure-form-items-list-field') ||
+					html.startsWith('<icure-form-date-picker') ||
+					html.startsWith('<icure-form-time-picker') ||
+					html.startsWith('<icure-form-date-time-picker') ||
+					html.startsWith('<icure-form-dropdown-field') ||
+					html.startsWith('<icure-form-radio-button') ||
+					html.startsWith('<icure-form-checkbox') ||
+					target.includes('icure-form-text-field') ||
+					target.includes('icure-form-measure-field') ||
+					target.includes('icure-form-number-field') ||
+					target.includes('icure-form-token-field') ||
+					target.includes('icure-form-items-list-field') ||
+					target.includes('icure-form-date-picker') ||
+					target.includes('icure-form-time-picker') ||
+					target.includes('icure-form-date-time-picker') ||
+					target.includes('icure-form-dropdown-field') ||
+					target.includes('icure-form-radio-button') ||
+					target.includes('icure-form-checkbox')
+				return inPatient && !inFieldComponent
+			}),
+		)
+	}
+
+	test('welcome stage has no WCAG 2.1 AA serious violations', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		const ours = await patientCardsViolations(page)
+		const critical = ours.filter((v) => v.impact === 'critical' || v.impact === 'serious')
+		expect(critical, JSON.stringify(critical.map((v) => ({ id: v.id, impact: v.impact, help: v.help })), null, 2)).toEqual([])
+	})
+
+	test('input stage has no WCAG 2.1 AA serious violations', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		const ours = await patientCardsViolations(page)
+		const critical = ours.filter((v) => v.impact === 'critical' || v.impact === 'serious')
+		expect(critical, JSON.stringify(critical.map((v) => ({ id: v.id, impact: v.impact, help: v.help })), null, 2)).toEqual([])
+	})
+
+	test('review stage has no WCAG 2.1 AA serious violations', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, sampleYaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await clickByClass(page, 'patient-cards__continue')
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		const ours = await patientCardsViolations(page)
+		const critical = ours.filter((v) => v.impact === 'critical' || v.impact === 'serious')
+		expect(critical, JSON.stringify(critical.map((v) => ({ id: v.id, impact: v.impact, help: v.help })), null, 2)).toEqual([])
+	})
+})

--- a/test/e2e/patient-cards-radio-restore.spec.ts
+++ b/test/e2e/patient-cards-radio-restore.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect, Page } from '@playwright/test'
+
+// Regression coverage for radio/checkbox state restoration on back-navigation, edit-jumps, and
+// after re-flatten (Phase 4 conditional re-evaluation).
+
+async function gotoHarness(page: Page) {
+	await page.goto('/')
+	await page.waitForFunction(() => typeof (window as any).initForm === 'function', { timeout: 10_000 })
+}
+
+async function initPatientCards(page: Page, yaml: string) {
+	return await page.evaluate(async (y: string) => (window as any).initForm({ yaml: y, language: 'en', renderer: 'patient-cards' }), yaml)
+}
+
+async function waitForInternal(page: Page) {
+	await page.waitForFunction(
+		() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			return !!internal?.shadowRoot?.querySelector('.patient-cards')
+		},
+		{ timeout: 15_000 },
+	)
+}
+
+async function clickByClass(page: Page, cls: string) {
+	const ok = await page.evaluate((c: string) => {
+		const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+		const btn = internal?.shadowRoot?.querySelector(`.${c}`) as HTMLElement | null
+		if (!btn || (btn as HTMLButtonElement).disabled) return false
+		btn.click()
+		return true
+	}, cls)
+	if (!ok) throw new Error(`Button .${cls} not clickable`)
+	await page.waitForTimeout(150)
+}
+
+async function clickOption(page: Page, fieldTag: string, optionId: string) {
+	const ok = await page.evaluate(
+		({ fieldTag, optionId }: { fieldTag: string; optionId: string }) => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const fieldEl = internal?.shadowRoot?.querySelector(fieldTag)
+			const buttonGroup = fieldEl?.shadowRoot?.querySelector('icure-button-group')
+			const input = buttonGroup?.shadowRoot?.querySelector(`input[id="${optionId}"]`) as HTMLInputElement | null
+			if (!input) return false
+			input.click()
+			return true
+		},
+		{ fieldTag, optionId },
+	)
+	if (!ok) throw new Error(`Option ${optionId} on ${fieldTag} not clickable`)
+	await page.waitForTimeout(300)
+}
+
+async function isOptionChecked(page: Page, fieldTag: string, optionId: string): Promise<boolean> {
+	return await page.evaluate(
+		({ fieldTag, optionId }: { fieldTag: string; optionId: string }) => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const fieldEl = internal?.shadowRoot?.querySelector(fieldTag)
+			const buttonGroup = fieldEl?.shadowRoot?.querySelector('icure-button-group')
+			const input = buttonGroup?.shadowRoot?.querySelector(`input[id="${optionId}"]`) as HTMLInputElement | null
+			return !!input && input.checked
+		},
+		{ fieldTag, optionId },
+	)
+}
+
+const simpleYaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: gender
+        type: radio-button
+        options:
+          GENDER|male|1: Male
+          GENDER|female|1: Female
+      - field: allergies
+        type: checkbox
+        options:
+          ALLERGIES|milk|1: Milk
+          ALLERGIES|eggs|1: Eggs
+      - field: notes
+        type: text-field
+`
+
+const threeRadiosYaml = `
+form: F
+sections:
+  - section: S
+    fields:
+      - field: R1
+        type: radio-button
+        options:
+          R1|1|1: Yes
+          R1|2|1: No
+      - field: R2
+        type: radio-button
+        options:
+          R2|1|1: Yes
+          R2|2|1: No
+      - field: R3
+        type: radio-button
+        options:
+          R3|1|1: Yes
+          R3|2|1: No
+`
+
+test.describe('Radio / checkbox back-restore', () => {
+	test('radio selection survives Continue → Back', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, simpleYaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(500)
+		await clickOption(page, 'icure-form-radio-button', 'GENDER|female|1')
+		await page.waitForTimeout(500)
+		expect(await isOptionChecked(page, 'icure-form-radio-button', 'GENDER|female|1')).toBe(true)
+		await clickByClass(page, 'patient-cards__continue')
+		await page.waitForTimeout(300)
+		await clickByClass(page, 'patient-cards__back')
+		await page.waitForTimeout(1500)
+		expect(await isOptionChecked(page, 'icure-form-radio-button', 'GENDER|female|1')).toBe(true)
+	})
+
+	test('checkbox selection survives Continue → Back (control)', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, simpleYaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await clickByClass(page, 'patient-cards__continue')
+		await page.waitForTimeout(500)
+		await clickOption(page, 'icure-form-checkbox', 'ALLERGIES|milk|1')
+		await page.waitForTimeout(300)
+		expect(await isOptionChecked(page, 'icure-form-checkbox', 'ALLERGIES|milk|1')).toBe(true)
+		await clickByClass(page, 'patient-cards__continue')
+		await page.waitForTimeout(300)
+		await clickByClass(page, 'patient-cards__back')
+		await page.waitForTimeout(1500)
+		expect(await isOptionChecked(page, 'icure-form-checkbox', 'ALLERGIES|milk|1')).toBe(true)
+	})
+
+	test('three consecutive radios all restore correctly on back-navigation', async ({ page }) => {
+		// Reproduces a user-reported pattern: 1 → 2 → 3 forward, then 3 → 2 → 1 back. Each radio
+		// has DIFFERENT option ids, so an "options stuck on first field" bug surfaces as
+		// unchecked-or-missing inputs on the middle card(s).
+		await gotoHarness(page)
+		await initPatientCards(page, threeRadiosYaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(500)
+
+		// Card 0: R1 = Yes (R1|1|1)
+		await clickOption(page, 'icure-form-radio-button', 'R1|1|1')
+		await page.waitForTimeout(400)
+		await clickByClass(page, 'patient-cards__continue')
+		await page.waitForTimeout(400)
+		// Card 1: R2 = No (R2|2|1)
+		await clickOption(page, 'icure-form-radio-button', 'R2|2|1')
+		await page.waitForTimeout(400)
+		await clickByClass(page, 'patient-cards__continue')
+		await page.waitForTimeout(400)
+		// Card 2: R3 = Yes (R3|1|1)
+		await clickOption(page, 'icure-form-radio-button', 'R3|1|1')
+		await page.waitForTimeout(400)
+
+		// Verify R3 is checked at its own card.
+		expect(await isOptionChecked(page, 'icure-form-radio-button', 'R3|1|1')).toBe(true)
+
+		// Back to card 1 (R2). It should still show R2|2|1 checked.
+		await clickByClass(page, 'patient-cards__back')
+		await page.waitForTimeout(800)
+		expect(await isOptionChecked(page, 'icure-form-radio-button', 'R2|2|1')).toBe(true)
+
+		// Back to card 0 (R1). It should still show R1|1|1 checked.
+		await clickByClass(page, 'patient-cards__back')
+		await page.waitForTimeout(800)
+		expect(await isOptionChecked(page, 'icure-form-radio-button', 'R1|1|1')).toBe(true)
+	})
+
+	test('radio selection survives review → edit-jump back to its card', async ({ page }) => {
+		await gotoHarness(page)
+		await initPatientCards(page, simpleYaml)
+		await waitForInternal(page)
+		await clickByClass(page, 'patient-cards__start')
+		await page.waitForTimeout(500)
+		await clickOption(page, 'icure-form-radio-button', 'GENDER|male|1')
+		await page.waitForTimeout(500)
+		await clickByClass(page, 'patient-cards__continue')
+		await page.waitForTimeout(300)
+		await clickByClass(page, 'patient-cards__continue')
+		await page.waitForTimeout(300)
+		await clickByClass(page, 'patient-cards__continue--to-review')
+		await page.waitForTimeout(500)
+		await page.evaluate(() => {
+			const internal = document.querySelector('icure-form')?.shadowRoot?.querySelector('icure-patient-cards-internal') as any
+			const row = internal?.shadowRoot?.querySelector('.patient-cards__review-row[data-card-index="0"]')
+			const btn = row?.querySelector('.patient-cards__review-edit') as HTMLElement | null
+			btn?.click()
+		})
+		await page.waitForTimeout(800)
+		expect(await isOptionChecked(page, 'icure-form-radio-button', 'GENDER|male|1')).toBe(true)
+	})
+})

--- a/test/e2e/test-page/harness.ts
+++ b/test/e2e/test-page/harness.ts
@@ -1,7 +1,10 @@
 // Import the default theme to register all custom elements
 import '../../../src/components/themes/default/index'
+// Side-effect import: register the patient-cards internal element.
+import '../../../src/components/icure-form/renderer/patient-cards/register'
 
 import { Form, Field, Group, Subform, FieldMetadata, Validator } from '../../../src/components/model'
+import { flatten as patientCardsFlatten } from '../../../src/components/icure-form/renderer/patient-cards/flatten'
 import { ContactFormValuesContainer, BridgedFormValuesContainer } from '../../../src/icure'
 import { Version } from '../../../src/generic'
 import { makeInterpreter } from '../../../src/utils/interpreter'
@@ -24,6 +27,15 @@ function uuid() {
 interface InitFormOptions {
 	yaml: string
 	language?: string
+	renderer?: string
+	/** Patient-cards renderer only: max interactive fields per card (1 or 2). */
+	questionsPerCard?: number
+	/**
+	 * Optional pre-fill: values set on the BridgedFormValuesContainer BEFORE the renderer is mounted.
+	 * Used by Phase 5 tests to simulate "resume" scenarios where the patient is returning to a
+	 * partially-completed form.
+	 */
+	prefill?: Array<{ label: string; language?: string; value: string }>
 }
 
 interface InitFormResult {
@@ -86,7 +98,7 @@ const extractFormulas = (
 	}) ?? []
 
 async function initForm(options: InitFormOptions): Promise<InitFormResult> {
-	const { yaml: yamlContent, language = 'en' } = options
+	const { yaml: yamlContent, language = 'en', renderer = 'form', prefill, questionsPerCard } = options
 
 	// Parse the form
 	let parsed: any
@@ -197,6 +209,20 @@ async function initForm(options: InitFormOptions): Promise<InitFormResult> {
 
 	await bridgedFormValuesContainer.init()
 
+	// Phase 5: apply prefill values BEFORE the renderer mounts. BridgedFormValuesContainer requires
+	// at least one registered listener for its setValue mutations to propagate (otherwise the new
+	// container is silently dropped). Register a tracking listener to capture each mutation.
+	let currentFvc: BridgedFormValuesContainer = bridgedFormValuesContainer
+	const prefillListener = (newValue: BridgedFormValuesContainer) => {
+		currentFvc = newValue
+	}
+	bridgedFormValuesContainer.registerChangeListener(prefillListener)
+	if (prefill?.length) {
+		for (const p of prefill) {
+			currentFvc.setValue(p.label, p.language ?? language, { content: { [p.language ?? language]: { type: 'string', value: p.value } as any } } as any)
+		}
+	}
+
 	// Remove any previous form
 	const container = document.getElementById('form-container')!
 	while (container.firstChild) {
@@ -206,18 +232,24 @@ async function initForm(options: InitFormOptions): Promise<InitFormResult> {
 	// Create and configure icure-form element
 	const icureFormEl = document.createElement('icure-form') as any
 	icureFormEl.form = form
-	icureFormEl.formValuesContainer = bridgedFormValuesContainer
+	// Use `currentFvc` so that any prefill applied above is reflected in the renderer's initial container.
+	icureFormEl.formValuesContainer = currentFvc
+	;(window as any).__currentFvc = currentFvc
 
-	// Register change listener to update icure-form when the container changes (e.g., subform add/remove)
-	bridgedFormValuesContainer.registerChangeListener((newValue: BridgedFormValuesContainer) => {
+	// Register change listener to update icure-form when the container changes (e.g., subform add/remove).
+	// Shares the same listener array as `prefillListener`, so further mutations propagate here too.
+	currentFvc.registerChangeListener((newValue: BridgedFormValuesContainer) => {
 		icureFormEl.formValuesContainer = newValue
 		;(window as any).__currentFvc = newValue
 	})
 	icureFormEl.language = language
 	icureFormEl.readonly = false
 	icureFormEl.displayMetadata = false
-	icureFormEl.renderer = 'form'
+	icureFormEl.renderer = renderer
 	icureFormEl.labelPosition = 'above'
+	if (questionsPerCard !== undefined) {
+		icureFormEl.questionsPerCard = questionsPerCard
+	}
 
 	const translationTables = form.translations
 	if (translationTables) {
@@ -244,4 +276,40 @@ async function initForm(options: InitFormOptions): Promise<InitFormResult> {
 	if (!fvc) return null
 	const values = fvc.getValues(() => [null])
 	return values
+}
+
+// Patient-cards helpers exposed for Playwright tests:
+;(window as any).patientCardsFlatten = (formJson: any) => {
+	const f = Form.parse(formJson)
+	return patientCardsFlatten(f).map((c) => ({
+		sectionTitle: c.sectionTitle,
+		groupTitle: c.groupTitle,
+		fieldLabels: c.fields.map((field) => field.field),
+	}))
+}
+;(window as any).parseForm = (formJson: any) => Form.parse(formJson)
+;(window as any).formToJson = (formJson: any) => Form.parse(formJson).toJson()
+
+// Cycle-detection test helper. Builds a Form whose Subform tree cycles via mutation
+// (Form.parse rejects duplicate subform ids, so this can't be constructed from JSON).
+import { Section as ModelSection } from '../../../src/components/model'
+;(window as any).testCyclicSubformFlatten = () => {
+	const warnings: string[] = []
+	const origWarn = console.warn
+	console.warn = (...args: unknown[]) => {
+		warnings.push(String(args[0] ?? ''))
+	}
+	try {
+		const formA = new Form('A', [])
+		const formB = new Form('B', [])
+		// Subform from A pointing to B, and from B pointing to A — mutual reference.
+		const subformAToB = new Subform('SubB', { b: formB }, { id: 'subB' })
+		const subformBToA = new Subform('SubA', { a: formA }, { id: 'subA' })
+		formA.sections = [new ModelSection('SecA', [subformAToB])]
+		formB.sections = [new ModelSection('SecB', [subformBToA])]
+		const cards = patientCardsFlatten(formA)
+		return { cardCount: cards.length, warnings }
+	} finally {
+		console.warn = origWarn
+	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@axe-core/playwright@npm:^4.11.3":
+  version: 4.11.3
+  resolution: "@axe-core/playwright@npm:4.11.3"
+  dependencies:
+    axe-core: ~4.11.4
+  peerDependencies:
+    playwright-core: ">= 1.0.0"
+  checksum: 33456446d0064ce4e99a362bec83801c711275abff99e71d26eaa1e7549c71d88d3aa64bdaac9438853bcb60e3904e1c9b322a5178efac26c0eef546047c80ce
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.26.2":
   version: 7.26.2
   resolution: "@babel/code-frame@npm:7.26.2"
@@ -704,6 +715,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@icure/form@workspace:."
   dependencies:
+    "@axe-core/playwright": ^4.11.3
     "@babel/core": ^7.26.10
     "@babel/eslint-parser": ^7.26.10
     "@babel/traverse": ^7.26.10
@@ -3106,6 +3118,13 @@ __metadata:
   version: 4.10.3
   resolution: "axe-core@npm:4.10.3"
   checksum: e89fa5bcad9216f2de29bbdf95d6211d8c5b1025cbdcf56b6695c18b2e9a1eebd0b997a0141334169f6f062fc68fd39a5b97f86348d9f5be05958eade5c1ec78
+  languageName: node
+  linkType: hard
+
+"axe-core@npm:~4.11.4":
+  version: 4.11.4
+  resolution: "axe-core@npm:4.11.4"
+  checksum: a7b1bf7cbec7a3c5752de11f28b552bf1ef7cbe9191bfeb887bc8fe02d727feadab4889426d7da11e6a9f18045aa6e4249112f5b7590fa02c79f97f2a9f40cd5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- New `renderer="patient-cards"` for `<icure-form>` that renders the form as a Typeform-style single-question-per-card flow (welcome → input → review → confirmation) with progress, computed-visibility re-flatten, per-card and cross-card validation, fast-forward resume from existing values, and focus management.
- Keyboard navigation on the patient-cards stage: Enter advances Start/Continue/Submit (capture-phase, document-level, so it works after a background click and pre-empts ProseMirror's Enter handling); digits 1‑9 toggle the matching radio/checkbox option on the current card.
- Visual cues: gray digit badges next to each radio/checkbox option (right-aligned) and a ↵ glyph inside the Start/Continue/Submit buttons. Driven by a new `keyboardHints` prop on `IcureButtonGroup` / `RadioButton` / `CheckBox` (opt-in; only patient-cards passes it).
- Review-page polish: rows now show the field's `shortLabel` (truncated with ellipsis, full text on hover) instead of the positional label, and radio/checkbox values render as the translated code labels from `FieldValue.codes` instead of the raw `true` boolean.

## Test plan
- [ ] `yarn test` — unit tests pass (pre-existing `subform-deletion.spec.ts` and `__mocks__/lit.js` failures are unchanged from `cardinal`)
- [ ] Run the demo app (`yarn start`) with `renderer="patient-cards"` and verify:
  - [ ] Welcome → Start advances to first card (Enter and click both work)
  - [ ] Enter advances through cards; on the last card it lands on the review screen; Enter on review submits
  - [ ] Digits 1‑9 toggle the matching option on radio and checkbox cards (with focus inside the card and on body after a background click)
  - [ ] Enter inside a single-line text field advances; Enter inside a multi-line text field inserts a newline
  - [ ] Digit badges appear on the right side of each option in 50% gray; ↵ badge appears inside the action button
  - [ ] Review page shows `shortLabel` (truncated) and the translated code label(s) for radio / checkbox answers
- [ ] Existing patient-cards Playwright specs (`test/e2e/patient-cards-phase*.spec.ts`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)