### PR TITLE
Allow delete cross + delegated edition to coexist on a token field

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -54,6 +54,8 @@ Tokens in a `tokens-list` field can now show an individual delete cross. Set `to
   tokenDeleteButton: true
 ```
 
+This combines with `delegatedEdition`: the delete cross removes its token directly, while clicking the token body still delegates the edition to the host.
+
 ### Originating DOM event forwarded to `actionListener`
 
 The `actionListener` signature gained an optional third argument:

--- a/app/e2e/sample-11.spec.ts
+++ b/app/e2e/sample-11.spec.ts
@@ -21,7 +21,9 @@ async function getRenderedTokens(page: Page): Promise<string[]> {
 // page.mouse click lands on the right coordinates and reaches ProseMirror's
 // own click handler (programmatic .click() would arrive with x/y = 0 and break
 // per-token resolution).
-async function allergiesGeometry(page: Page): Promise<{ editor: { left: number; top: number; right: number; bottom: number }; tokens: { cx: number; cy: number }[] }> {
+async function allergiesGeometry(
+	page: Page,
+): Promise<{ editor: { left: number; top: number; right: number; bottom: number }; tokens: { cx: number; cy: number; del: { cx: number; cy: number } | null }[] }> {
 	return page.evaluate(() => {
 		const demo = document.querySelector('demo-app')
 		const visible = Array.from(demo?.shadowRoot?.querySelectorAll('decorated-form') ?? []).find((df) => (df.parentElement as HTMLElement | null)?.style.display !== 'none') as HTMLElement | undefined
@@ -33,7 +35,9 @@ async function allergiesGeometry(page: Page): Promise<{ editor: { left: number; 
 		const er = editor.getBoundingClientRect()
 		const tokens = Array.from(editor.querySelectorAll('li')).map((li) => {
 			const r = ((li.querySelector('.token') as HTMLElement | null) ?? li).getBoundingClientRect()
-			return { cx: r.left + r.width / 2, cy: r.top + r.height / 2 }
+			const delEl = li.querySelector('.token-delete') as HTMLElement | null
+			const dr = delEl?.getBoundingClientRect()
+			return { cx: r.left + r.width / 2, cy: r.top + r.height / 2, del: dr ? { cx: dr.left + dr.width / 2, cy: dr.top + dr.height / 2 } : null }
 		})
 		return { editor: { left: er.left, top: er.top, right: er.right, bottom: er.bottom }, tokens }
 	})
@@ -53,6 +57,15 @@ async function clickToken(page: Page, index: number): Promise<void> {
 	const { tokens } = await allergiesGeometry(page)
 	if (!tokens[index]) throw new Error(`No token at index ${index} (have ${tokens.length})`)
 	await page.mouse.click(tokens[index].cx, tokens[index].cy)
+	await page.waitForTimeout(600)
+}
+
+// Click the delete cross of the token at the given index — removes that token.
+async function clickTokenDelete(page: Page, index: number): Promise<void> {
+	const { tokens } = await allergiesGeometry(page)
+	const del = tokens[index]?.del
+	if (!del) throw new Error(`No delete cross for token at index ${index} (have ${tokens.length})`)
+	await page.mouse.click(del.cx, del.cy)
 	await page.waitForTimeout(600)
 }
 
@@ -114,7 +127,9 @@ test.describe('11-delegated-edition', () => {
 		// the assertion below would pass vacuously in English.
 		const activeLanguage = await page.evaluate(() => {
 			const demo = document.querySelector('demo-app')
-			const visible = Array.from(demo?.shadowRoot?.querySelectorAll('decorated-form') ?? []).find((df) => (df.parentElement as HTMLElement | null)?.style.display !== 'none') as (HTMLElement & { language?: string }) | undefined
+			const visible = Array.from(demo?.shadowRoot?.querySelectorAll('decorated-form') ?? []).find((df) => (df.parentElement as HTMLElement | null)?.style.display !== 'none') as
+				| (HTMLElement & { language?: string })
+				| undefined
 			return visible?.language
 		})
 		expect(activeLanguage).toBe('fr')
@@ -132,6 +147,29 @@ test.describe('11-delegated-edition', () => {
 		// same service in place — the text changes, the count does NOT grow.
 		await clickToken(page, 0)
 		expect(await getRenderedTokens(page)).toEqual(['Edited Allergy #1', 'Allergy #2'])
+		expect(await getTokenCount(page)).toBe(2)
+	})
+
+	test('delete cross and delegated edition coexist on the same field', async ({ page }) => {
+		await clickEmptyArea(page)
+		await clickEmptyArea(page)
+		await clickEmptyArea(page)
+		expect(await getRenderedTokens(page)).toEqual(['Allergy #1', 'Allergy #2', 'Allergy #3'])
+		expect(await getTokenCount(page)).toBe(3)
+
+		// Each token shows a delete cross (tokenDeleteButton + delegatedEdition).
+		const { tokens } = await allergiesGeometry(page)
+		expect(tokens.every((t) => t.del !== null)).toBe(true)
+
+		// Delete cross removes just that token (count drops, others intact) —
+		// delegated edition does NOT swallow the delete click.
+		await clickTokenDelete(page, 1)
+		expect(await getRenderedTokens(page)).toEqual(['Allergy #1', 'Allergy #3'])
+		expect(await getTokenCount(page)).toBe(2)
+
+		// Clicking a token's body still delegates the edit (in place, no growth).
+		await clickToken(page, 0)
+		expect(await getRenderedTokens(page)).toEqual(['Edited Allergy #1', 'Allergy #3'])
 		expect(await getTokenCount(page)).toBe(2)
 	})
 

--- a/app/samples/11-delegated-edition.yaml
+++ b/app/samples/11-delegated-edition.yaml
@@ -26,6 +26,7 @@ sections:
             multiline: true
             rowSpan: 3
             delegatedEdition: true
+            tokenDeleteButton: true
             event: edit-allergies
           - field: allergyCount
             type: number-field
@@ -46,6 +47,6 @@ sections:
             shortLabel: reset-allergies
             span: 8
             event: reset-allergies
-      - field: "Demonstrates the delegatedEdition flag. When set on a token-field, clicks no longer open the inline editor — they fire the host actionListener with the field's `event` name. Clicking an EXISTING token passes `{ valueId, content }` (valueId = the token's service id); clicking an EMPTY area passes no payload. The host (decorated-form.ts) appends a new token on an empty-area click and edits the clicked token in place (prefixing 'Edited ') when a valueId is present. Test: click an empty part of the Allergies field — a new token is added and the Token count goes up; click an existing token — its text changes in place and the count stays the same; click Reset — the list clears."
+      - field: "Demonstrates the delegatedEdition flag combined with tokenDeleteButton. Clicks no longer open the inline editor — they fire the host actionListener with the field's `event` name. Clicking an EXISTING token's body passes `{ valueId, content }` (valueId = the token's service id); clicking an EMPTY area passes no payload. The host (decorated-form.ts) appends a new token on an empty-area click and edits the clicked token in place (prefixing 'Edited ') when a valueId is present. Each token also shows a delete cross that removes just that token directly. Test: click an empty part of the Allergies field — a new token is added and the Token count goes up; click a token's body — its text changes in place and the count stays the same; click a token's delete cross — that token is removed and the count goes down; click Reset — the list clears."
         type: label
         span: 24

--- a/src/components/icure-form/fields/token-field/token-field.ts
+++ b/src/components/icure-form/fields/token-field/token-field.ts
@@ -13,7 +13,9 @@ export class TokenField extends Field {
 	// (valueId = the token's VersionedData key, i.e. the service id in the iCure
 	// bridge); clicking an empty area fires it with `undefined`. The handler is
 	// then responsible for mutating the values and triggering a re-render.
-	// Delegated click handling lives in the inner <icure-text-field>.
+	// Delegated click handling lives in the inner <icure-text-field>. This can be
+	// combined with `tokenDeleteButton`: the delete cross still removes its token
+	// directly, while clicking the token body delegates the edition.
 	@property({ type: Boolean }) delegatedEdition = false
 	@property() event?: string
 	@property() actionListener?: (event: string, payload: unknown, domEvent?: Event) => void = undefined
@@ -31,7 +33,7 @@ export class TokenField extends Field {
 			.lines="${this.lines}"
 			.displayedLabels="${this.displayedLabels}"
 			.defaultLanguage="${this.defaultLanguage}"
-			.tokenDeleteButton="${this.tokenDeleteButton && !this.delegatedEdition}"
+			.tokenDeleteButton="${this.tokenDeleteButton}"
 			schema="tokens-list"
 			.handleMetadataChanged=${this.handleMetadataChanged}
 			.handleValueChanged=${this.handleValueChanged}

--- a/src/components/icure-text-field/index.ts
+++ b/src/components/icure-text-field/index.ts
@@ -556,10 +556,12 @@ export class IcureTextField extends Field {
 					click: (view, event) => {
 						if (this.schema.includes('tokens-list')) {
 							const el = event.target as HTMLElement
-							// Delegated edition takes precedence: a click on an existing
-							// token fires the host actionListener with that token's
-							// identity, a click anywhere else fires it with no payload.
-							if (this.delegatedEdition && this.actionListener) {
+							// Delegated edition: a click on an existing token fires the host
+							// actionListener with that token's identity, a click anywhere
+							// else fires it with no payload. A click on the delete cross is
+							// excluded here so it falls through to the delete branch below —
+							// this lets delete and delegated edition coexist on one field.
+							if (this.delegatedEdition && this.actionListener && !(this.tokenDeleteButton && el?.closest?.('.token-delete'))) {
 								const node = el?.closest?.('.token') ? this.resolveTokenNodeAt(view, event) : undefined
 								this.actionListener(this.event ?? 'edit', node ? { valueId: node.attrs?.id, content: node.textContent } : undefined, event)
 								return
@@ -569,6 +571,15 @@ export class IcureTextField extends Field {
 								if (pos?.pos !== undefined) {
 									const rp = view.state.tr.doc.resolve(pos.pos)
 									this.view?.dispatch(view.state.tr.deleteRange(rp.before(), rp.after()))
+									// Persist the removal immediately. dispatchTransaction only
+									// flushes after a 10s debounce (or on blur); a readonly /
+									// delegated-edition editor never blurs, so without this the
+									// deletion would not reach the form values. Clearing trToSave
+									// stops the scheduled timeout from firing a redundant update.
+									if (this.view) {
+										this.trToSave = undefined
+										this.updateValue(this.view.state.tr)
+									}
 								}
 								return
 							}


### PR DESCRIPTION
## Summary

A token field could not previously have **both** `delegatedEdition` and `tokenDeleteButton`: the delete cross was force-disabled in delegated mode, and the delegated click branch ran first and swallowed every click. This makes the two features combine — clicking a token's **body** delegates the edition to the host, clicking its **delete cross** removes that token directly.

## Changes

- `token-field.ts`: forward `tokenDeleteButton` to the inner editor even when `delegatedEdition` is set (was `tokenDeleteButton && !delegatedEdition`).
- `icure-text-field` click handler: the delegated branch now ignores clicks on `.token-delete`, letting them fall through to the delete handler.
- Delete handler: flush the removal to the form values **immediately** instead of via the 10s debounce. A readonly/delegated editor never blurs, so without this the deletion updated the editor view but never persisted to the FVC.
- Sample 11 enables both flags; updated explainer.

## Test plan

- `yarn test:e2e:app` — sample-11 suite passes 10/10, including a new test asserting: delete cross removes the right token (count drops, others intact) **and** clicking a token body still delegates the edit in place.
- Verified live in the demo on a fresh server: crosses render (14×18), delete persists to the form values (count 3→2), delegated edit still works, no console errors.

Targets the unreleased 2.2.0 (the `Release 2.2.0` commit is already on main); merging this folds the fix into 2.2.0 before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)