### PR TITLE
Support computedProperties/readonly on action buttons; token field readonly & metadata fixes

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -4,6 +4,48 @@ This file summarises the user-facing features introduced in each version of `@ic
 
 ---
 
+## Unreleased
+
+### `computedProperties` and `readonly` on action buttons
+
+Action buttons (`type: action`) now honour `computedProperties` and `readonly`, just like regular fields. Previously these were dropped when the form was parsed.
+
+- `computedProperties.hidden` can show/hide a button reactively from a formula.
+- `readonly: true` (or `computedProperties.readonly`) renders the button **disabled**: it is greyed out and clicking it no longer fires the host `actionListener`.
+
+```yaml
+- field: Pay
+  type: action
+  event: pay
+  computedProperties:
+    hidden: |
+      const a = parseContent(amount[0]?.content)
+      return a == null || a <= 0   # hidden until Amount is positive
+
+- field: Check
+  type: action
+  event: check
+  computedProperties:
+    readonly: |
+      const a = parseContent(amount[0]?.content)
+      return a == null || a < 100  # disabled until Amount reaches 100
+
+- field: Disabled
+  type: action
+  event: noop
+  readonly: true                   # rendered disabled (non-clickable)
+```
+
+The formula returns `true` when the property should apply (truthy ⇒ hidden / readonly).
+
+See the live `01-components-gallery` (disabled button) and `02-formulas` (hidable + conditionally-disabled buttons) samples in the demo app (`yarn start`).
+
+### Fixed: `computedProperties.readonly` now actually applies
+
+`computedProperties.readonly` was silently ignored on **every** field — the renderer negated the `compute()` result wrapper (always truthy) instead of its `.value`, so the formula never took effect. It now unwraps `.value`, so a formula returning `true` correctly makes the field (or button) readonly.
+
+---
+
 ## 2.2.0 (2026-06-03)
 
 This release makes form editing *configurable*: token fields can delegate their edition to the host, individual tokens can be deleted, and the originating DOM event is forwarded to handlers. Under the hood, each text schema now owns a self-contained `SchemaSpec`.
@@ -55,6 +97,8 @@ Tokens in a `tokens-list` field can now show an individual delete cross. Set `to
 ```
 
 This combines with `delegatedEdition`: the delete cross removes its token directly, while clicking the token body still delegates the edition to the host.
+
+The delete cross is hidden when the field is `readonly`, so tokens cannot be removed in read-only forms. (It still shows under `delegatedEdition`, which keeps the inner editor read-only by design.)
 
 ### Originating DOM event forwarded to `actionListener`
 

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -4,7 +4,7 @@ This file summarises the user-facing features introduced in each version of `@ic
 
 ---
 
-## Unreleased
+## 2.2.1 (2026-06-15)
 
 ### `computedProperties` and `readonly` on action buttons
 

--- a/app/decorated-form.ts
+++ b/app/decorated-form.ts
@@ -258,7 +258,7 @@ export class DecoratedForm extends LitElement {
 				}
 			}) ?? []
 
-		const initialisedFormValueContainer = await new BridgedFormValuesContainer(
+		const initialisedFormValueContainer = new BridgedFormValuesContainer(
 			responsible,
 			contactFormValuesContainer,
 			makeInterpreter(),
@@ -347,6 +347,17 @@ export class DecoratedForm extends LitElement {
 			const fvc = this.formValuesContainer
 			this.redoStack = []
 			fvc && this.undoStack.push(fvc)
+
+			const originalServices = this.formValuesContainer?.getContactFormValuesContainer()?.coordinatedContact()?.services ?? []
+			const updatedServicesIds =
+				newValue
+					?.getContactFormValuesContainer()
+					?.coordinatedContact()
+					?.services?.map((s) => s.id) ?? []
+
+			const deletedServices = originalServices.filter((s) => !updatedServicesIds.includes(s.id))
+			console.log('Deleted', deletedServices)
+
 			this.formValuesContainer = newValue
 
 			const toSave = this.formValuesContainer.getContactFormValuesContainer()

--- a/app/samples/01-components-gallery.yaml
+++ b/app/samples/01-components-gallery.yaml
@@ -131,6 +131,12 @@ sections:
             computedProperties:
               payload: |
                 return { savedAt: new Date().toISOString() }
-      - field: "label renders static prose (this very text is itself a label). action renders a clickable button — clicking fires the host actionListener(event, payload, domEvent) callback with the field's event and its computed payload. The demo's actionListener is wired to alert(event). Test: click Save and confirm an alert pops up with 'save'."
+          - field: Disabled
+            type: action
+            shortLabel: disabled
+            span: 24
+            event: noop
+            readonly: true
+      - field: "label renders static prose (this very text is itself a label). action renders a clickable button — clicking fires the host actionListener(event, payload, domEvent) callback with the field's event and its computed payload. The demo's actionListener is wired to alert(event). Test: click Save and confirm an alert pops up with 'save'; the Disabled button is readonly, so clicking it does nothing."
         type: label
         span: 24

--- a/app/samples/02-formulas.yaml
+++ b/app/samples/02-formulas.yaml
@@ -113,3 +113,34 @@ sections:
       - field: "Number cross-field formula. Total = Unit price × Quantity, with Quantity seeded to 1 via computedProperties.defaultValue. Test: type 12.50 in Unit price — Total becomes 12.50 (Quantity defaulted to 1). Change Quantity to 4 — Total updates to 50."
         type: label
         span: 24
+  - section: Hidable action
+    fields:
+      - group: line
+        borderless: true
+        span: 24
+        fields:
+          - field: amount
+            type: number-field
+            shortLabel: Amount (€)
+            span: 8
+          - field: Pay
+            type: action
+            shortLabel: pay
+            span: 8
+            event: pay
+            computedProperties:
+              hidden: |
+                const a = parseContent(amount[0]?.content)
+                return a == null || a <= 0
+          - field: Check
+            type: action
+            shortLabel: check
+            span: 8
+            event: check
+            computedProperties:
+              readonly: |
+                const a = parseContent(amount[0]?.content)
+                return a == null || a < 100
+      - field: "computedProperties also drive action buttons. The Pay button's computedProperties.hidden returns true (hiding the button) until Amount is a positive number. The Check button's computedProperties.readonly returns true (disabling the button) while Amount is below 100. Test: the Pay button is hidden initially; type 20 in Amount — Pay appears but Check stays disabled (greyed out, non-clickable); raise Amount to 100 or more — Check becomes enabled and clicking it fires the 'check' event."
+        type: label
+        span: 24

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@icure/form",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "",
 	"main": "lib/index.js",
 	"scripts": {

--- a/src/components/common/styles/style.scss
+++ b/src/components/common/styles/style.scss
@@ -1280,6 +1280,12 @@ input[type='radio'] {
 	&:hover {
 		background-color: $label-color-hover;
 	}
+
+	&.icure-button__disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		pointer-events: none;
+	}
 }
 
 .icure-button-group {

--- a/src/components/icure-button/index.ts
+++ b/src/components/icure-button/index.ts
@@ -13,6 +13,7 @@ export class IcureButton extends LitElement {
 	@property() actionListener: (event: string, payload: unknown, domEvent?: Event) => void = () => undefined
 	@property() event: string
 	@property() payload: unknown
+	@property({ type: Boolean }) readonly = false
 
 	static get styles() {
 		return [baseCss]
@@ -25,7 +26,11 @@ export class IcureButton extends LitElement {
 		if (icureFormLogging) {
 			console.log(`Rendering button ${this.label}`)
 		}
-		return html`<div class="icure-button" style="button" @click="${(e: MouseEvent) => this.actionListener(this.event, this.payload, e)}">
+		return html`<div
+			class="icure-button${this.readonly ? ' icure-button__disabled' : ''}"
+			style="button"
+			@click="${(e: MouseEvent) => !this.readonly && this.actionListener(this.event, this.payload, e)}"
+		>
 			${this.label ? this.translationProvider?.(this.defaultLanguage, this.label) ?? this.label : this.label ?? ''}
 		</div>`
 	}

--- a/src/components/icure-form/fields/button/button.ts
+++ b/src/components/icure-form/fields/button/button.ts
@@ -21,6 +21,7 @@ export class Button extends LitElement {
 	@property() actionListener: (event: string, payload: unknown, domEvent?: Event) => void = () => undefined
 	@property() event: string
 	@property() payload: unknown
+	@property({ type: Boolean }) readonly = false
 
 	render(): TemplateResult {
 		return html`<icure-button
@@ -31,6 +32,7 @@ export class Button extends LitElement {
 			.actionListener="${this.actionListener}"
 			.event="${this.event}"
 			.payload="${this.payload}"
+			.readonly="${this.readonly}"
 		></icure-button>`
 	}
 }

--- a/src/components/icure-form/fields/token-field/token-field.ts
+++ b/src/components/icure-form/fields/token-field/token-field.ts
@@ -32,6 +32,7 @@ export class TokenField extends Field {
 			.multiline="${this.multiline}"
 			.lines="${this.lines}"
 			.displayedLabels="${this.displayedLabels}"
+			.displayMetadata="${this.displayMetadata}"
 			.defaultLanguage="${this.defaultLanguage}"
 			.tokenDeleteButton="${this.tokenDeleteButton}"
 			schema="tokens-list"

--- a/src/components/icure-form/renderer/form/form.ts
+++ b/src/components/icure-form/renderer/form/form.ts
@@ -142,7 +142,7 @@ export const render: Renderer = async (
 			.handleMetadataChanged=${handleMetadataChangedProvider(formsValueContainer)}
 			.styleOptions="${fg.styleOptions}"
 			.actionListener="${actionListener}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-text-field>`
 	}
 
@@ -170,7 +170,7 @@ export const render: Renderer = async (
 			.delegatedEdition="${!!fg.delegatedEdition}"
 			.event="${fg.event}"
 			.actionListener="${actionListener}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-token-field>`
 	}
 
@@ -194,7 +194,7 @@ export const render: Renderer = async (
 			.handleValueChanged=${handleValueChangedProvider(formsValueContainer, fg, props.defaultOwner)}
 			.handleMetadataChanged=${handleMetadataChangedProvider(formsValueContainer)}
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-items-list-field>`
 	}
 
@@ -215,7 +215,7 @@ export const render: Renderer = async (
 			.handleValueChanged=${handleValueChangedProvider(formsValueContainer, fg, props.defaultOwner)}
 			.handleMetadataChanged=${handleMetadataChangedProvider(formsValueContainer)}
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-measure-field>`
 	}
 
@@ -235,7 +235,7 @@ export const render: Renderer = async (
 			.handleValueChanged=${handleValueChangedProvider(formsValueContainer, fg, props.defaultOwner)}
 			.handleMetadataChanged=${handleMetadataChangedProvider(formsValueContainer)}
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-number-field>`
 	}
 
@@ -255,7 +255,7 @@ export const render: Renderer = async (
 			.handleValueChanged=${handleValueChangedProvider(formsValueContainer, fg, props.defaultOwner)}
 			.handleMetadataChanged=${handleMetadataChangedProvider(formsValueContainer)}
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-date-picker>`
 	}
 
@@ -275,7 +275,7 @@ export const render: Renderer = async (
 			.handleValueChanged=${handleValueChangedProvider(formsValueContainer, fg, props.defaultOwner)}
 			.handleMetadataChanged=${handleMetadataChangedProvider(formsValueContainer)}
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-time-picker>`
 	}
 
@@ -295,7 +295,7 @@ export const render: Renderer = async (
 			.handleValueChanged=${handleValueChangedProvider(formsValueContainer, fg, props.defaultOwner)}
 			.handleMetadataChanged=${handleMetadataChangedProvider(formsValueContainer)}
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-date-time-picker>`
 	}
 
@@ -321,7 +321,7 @@ export const render: Renderer = async (
 			.handleValueChanged=${handleValueChangedProvider(formsValueContainer, fg, props.defaultOwner)}
 			.handleMetadataChanged=${handleMetadataChangedProvider(formsValueContainer)}
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-dropdown-field>`
 	}
 
@@ -347,7 +347,7 @@ export const render: Renderer = async (
 			.handleValueChanged=${handleValueChangedProvider(formsValueContainer, fg, props.defaultOwner)}
 			.handleMetadataChanged=${handleMetadataChangedProvider(formsValueContainer)}
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-radio-button>`
 	}
 
@@ -374,7 +374,7 @@ export const render: Renderer = async (
 			.handleValueChanged="${handleValueChangedProvider(formsValueContainer, fg, props.defaultOwner)}"
 			.handleMetadataChanged="${handleMetadataChangedProvider(formsValueContainer)}"
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-checkbox>`
 	}
 
@@ -390,6 +390,7 @@ export const render: Renderer = async (
 			.event="${fg.event !== undefined ? fg.event : fg.computedProperties?.event ? (await formsValueContainer?.compute(fg.computedProperties?.event))?.value : 'submit'}"
 			.payload="${fg.payload !== undefined ? fg.payload : fg.computedProperties?.payload ? (await formsValueContainer?.compute(fg.computedProperties?.payload))?.value : undefined}"
 			.styleOptions="${fg.styleOptions}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-button>`
 	}
 
@@ -403,7 +404,7 @@ export const render: Renderer = async (
 			.translationProvider="${translationProvider ?? (form.translations && defaultTranslationProvider(form.translations))}"
 			.validationErrorsProvider="${getValidationErrorProvider(formsValueContainer, fg)}"
 			.styleOptions="${fg.styleOptions}"
-			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !(await formsValueContainer?.compute(fg.computedProperties?.readonly)) : false)}"
+			.readonly="${readonly || fg.readonly || (fg.computedProperties?.readonly ? !!(await formsValueContainer?.compute(fg.computedProperties?.readonly))?.value : false)}"
 		></icure-form-label>`
 	}
 

--- a/src/components/icure-text-field/index.ts
+++ b/src/components/icure-text-field/index.ts
@@ -291,7 +291,7 @@ export class IcureTextField extends Field {
 				${this.displayedLabels ? generateLabels(this.displayedLabels, this.language(), this.translate ? this.translationProvider : undefined) : nothing}
 				<div class="icure-input-metadata-container">
 					<div class="icure-input ${validationError ? 'icure-input__validationError' : ''} ${this.displayMetadata && metadata ? 'icure-input__withMetadata' : ''}">
-						<div id="editor" class="${this.schema}${this.tokenDeleteButton ? ' with-token-delete' : ''}" style="min-height: calc( ${this.lines}rem + 5px )"></div>
+						<div id="editor" class="${this.schema}${this.tokenDeleteButton && (!this.readonly || this.delegatedEdition) ? ' with-token-delete' : ''}" style="min-height: calc( ${this.lines}rem + 5px )"></div>
 						${!this.displayMetadata && this.defaultValueProvider ? html`<div id="reset" class="reset-button" @click="${async () => await this.reset(renderHash)}">${resetPicto}</div` : nothing}
 					</div>
 						${
@@ -895,7 +895,7 @@ export class MetadataButtonBarWrapper extends LitElement {
 
 	render() {
 		const parent = (this.shadowRoot?.host?.closest('div#root')?.parentNode as ShadowRoot)?.host as IcureTextField
-		if (!parent || !this.id) {
+		if (!parent || !this.id || !parent.displayMetadata) {
 			return
 		}
 

--- a/src/components/model/index.ts
+++ b/src/components/model/index.ts
@@ -1038,8 +1038,35 @@ export class Label extends Field {
 }
 
 export class Button extends Field {
-	constructor(label: string, { shortLabel, grows, span, event, payload }: { shortLabel?: string; grows?: boolean; span?: number; rowSpan?: number; event?: string; payload?: unknown }) {
-		super('action', label, { shortLabel, grows, span, event, payload })
+	constructor(
+		label: string,
+		{
+			shortLabel,
+			grows,
+			span,
+			rowSpan,
+			readonly,
+			computedProperties,
+			styleOptions,
+			validators,
+			translate,
+			event,
+			payload,
+		}: {
+			shortLabel?: string
+			grows?: boolean
+			span?: number
+			rowSpan?: number
+			readonly?: boolean
+			computedProperties?: { [_key: string]: string }
+			styleOptions?: { width: number; direction: string; span: number; rows: number; alignItems: string }
+			validators?: Validator[]
+			translate?: boolean
+			event?: string
+			payload?: unknown
+		},
+	) {
+		super('action', label, { shortLabel, grows, span, rowSpan, readonly, computedProperties, styleOptions, validators, translate, event, payload })
 	}
 	override copyIfNeeded(properties: Partial<Button>): Button {
 		return hasChanges(this, properties) ? new Button(this.field, { ...this, ...properties }) : this

--- a/test/icure-form/test.spec.ts
+++ b/test/icure-form/test.spec.ts
@@ -1,6 +1,6 @@
-import { strictEqual } from 'assert'
+import { strictEqual, deepStrictEqual } from 'assert'
 import YAML from 'yaml'
-import { Form, Section, Group, TextField, NumberField, DatePicker, TimePicker, DateTimePicker, MeasureField } from '../../src/components/model'
+import { Form, Section, Group, TextField, NumberField, DatePicker, TimePicker, DateTimePicker, MeasureField, Button, Field } from '../../src/components/model'
 
 describe('Form parsing tests', () => {
 	it('should Render simple form', () => {
@@ -705,5 +705,27 @@ sections:
 }`)
 		const form = Form.parse(toParse)
 		strictEqual(form.sections[0].fields[0].clazz, 'field')
+	})
+
+	it('should retain computedProperties and readonly on an action button after parse', () => {
+		const button = Field.parse({
+			clazz: 'field',
+			field: 'Pay',
+			type: 'action',
+			shortLabel: 'pay',
+			readonly: true,
+			event: 'pay',
+			computedProperties: { hidden: 'return amount <= 0' },
+		} as any) as Button
+
+		strictEqual(button instanceof Button, true)
+		strictEqual(button.readonly, true)
+		strictEqual(button.event, 'pay')
+		deepStrictEqual(button.computedProperties, { hidden: 'return amount <= 0' })
+
+		// computedProperties and readonly must survive serialization round-trip too
+		const roundTripped = Field.parse(JSON.parse(JSON.stringify(button)) as any) as Button
+		strictEqual(roundTripped.readonly, true)
+		deepStrictEqual(roundTripped.computedProperties, { hidden: 'return amount <= 0' })
 	})
 })


### PR DESCRIPTION
## Summary

Makes `computedProperties` and `readonly` work on action buttons, fixes a long-standing bug where `computedProperties.readonly` never applied to *any* field, and fixes two token-field issues around readonly mode and metadata.

## Action buttons

- **`computedProperties` / `readonly` now reach action buttons.** The `Button` model constructor only forwarded `{ shortLabel, grows, span, event, payload }`, so `computedProperties`, `readonly`, `rowSpan` and `styleOptions` were silently dropped during `Field.parse()`. The constructor now forwards them.
- **A readonly button renders disabled** — greyed out, `cursor: not-allowed`, and clicking it no longer fires the host `actionListener`. `readonly` flows through `icure-form-button` → `icure-button`, with a new `.icure-button__disabled` style.

## Bug fix: `computedProperties.readonly` never applied (any field)

The renderer negated the `compute()` result **wrapper** (`{ value, dependencies }`, always truthy) instead of its `.value`, so computed readonly was always `false`. Now it unwraps `.value` (formula returns `true` ⇒ readonly). This also makes the existing `05-conditional-actions` "lock notes" example actually work.

## Token field fixes

- The per-token **delete cross** is hidden when the field is `readonly` (still shown under `delegatedEdition`, which keeps the inner editor readonly by design).
- **`displayMetadata` now controls the per-token (i) button**: `TokenField` forwards `displayMetadata` to the inner field, and `MetadataButtonBarWrapper` respects it.

## Demo samples

- `01-components-gallery` (Label & action): a disabled (readonly) action button.
- `02-formulas`: a hidable **Pay** button (`computedProperties.hidden`) and a **Check** button disabled until Amount reaches 100 (`computedProperties.readonly`).

## Tests

- New parse test asserting an action button retains `computedProperties` and `readonly` through parse + serialization round-trip.
- All 10 demo samples still parse; full suite 24/24 (the lone `test/__mocks__/lit.js` failure is a pre-existing haste-map quirk, unrelated).

## Note

This branch also carries pre-existing working-tree changes that predate this work: debug logging in `app/decorated-form.ts` and a version bump to `2.2.1` in `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)