### PR TITLE
Fix setValue removing history-backed services on empty

### DIFF
--- a/src/icure/form-values-container.ts
+++ b/src/icure/form-values-container.ts
@@ -928,6 +928,32 @@ export class ContactFormValuesContainer implements FormValuesContainer<Service, 
 
 			let newCurrentContact: Contact
 			if (!Object.entries(newContents).filter(([, cnt]) => cnt !== undefined).length) {
+				// The `getServicesInHistory` lookup above reads `indexedServices`, which is built from
+				// `[currentContact, ...contactsHistory]` — so finding the service does NOT prove it lives in
+				// history: it may exist only in the current contact, in which case removing it is correct.
+				// We therefore scan the history contacts explicitly. If a history contact both holds the
+				// service and links it to this form via a subContact (the exact condition under which the
+				// constructor re-indexes it), then merely removing it from the current contact would make the
+				// old value reappear on reload. In that case we keep it with an `endOfLife` tombstone instead
+				// (same strategy as `removeChild`).
+				const now = Date.now()
+				const serviceInHistory = this.contactsHistory.some(
+					(ctc) =>
+						(ctc.services ?? []).some((s) => s.id === service.id) &&
+						(ctc.subContacts ?? []).some((sc) => sc.formId === this.rootForm.id && (sc.services ?? []).some((sr) => sr.serviceId === service.id)),
+				)
+				const currentServices = this.currentContact.services ?? []
+				const isPresentInCurrentContact = currentServices.some((s) => s.id === service.id)
+
+				let newServices: Service[]
+				if (serviceInHistory) {
+					// Keep a tombstone so the deletion overrides the value still present in history.
+					const eolService = new Service({ id: service.id, created: service.created, modified: now, endOfLife: now })
+					newServices = isPresentInCurrentContact ? currentServices.map((s) => (s.id === service.id ? eolService : s)) : [...currentServices, eolService]
+				} else {
+					// The service exists only in the current contact, so it is safe to drop entirely.
+					newServices = isPresentInCurrentContact ? currentServices.filter((s) => s.id !== service.id) : [...currentServices]
+				}
 				newCurrentContact = {
 					...this.currentContact,
 					subContacts: (this.currentContact.subContacts ?? []).some((sc) => sc.formId === this.rootForm.id)
@@ -942,9 +968,7 @@ export class ContactFormValuesContainer implements FormValuesContainer<Service, 
 								}
 						  })
 						: (this.currentContact.subContacts ?? []).concat({ formId: this.rootForm.id, services: [{ serviceId: service.id }] }),
-					services: (this.currentContact.services ?? []).some((s) => s.id === service.id)
-						? (this.currentContact.services ?? []).filter((s) => s.id !== service.id)
-						: [...(this.currentContact.services ?? [])],
+					services: newServices,
 				}
 			} else {
 				newService.content = newContents

--- a/test/icure-form/setvalue-empty.spec.ts
+++ b/test/icure-form/setvalue-empty.spec.ts
@@ -1,0 +1,130 @@
+import { Contact, Form as ICureForm, Service } from '@icure/api'
+import { ContactFormValuesContainer } from '../../src/icure/form-values-container'
+
+/**
+ * Tests for emptying a field (setValue with no content) and how the underlying
+ * service is treated depending on whether it also exists in a history contact.
+ *
+ * - A service that exists ONLY in the current contact can be removed entirely:
+ *   nothing in history would resurface it.
+ * - A service that also lives in a history contact (linked to this form via a
+ *   subContact) must NOT be removed — it would reappear from history on reload.
+ *   It must be kept with an `endOfLife` tombstone instead.
+ */
+
+const FORM_ID = 'form-id'
+const FORM_TEMPLATE_ID = 'form-template-id'
+const FIELD_LABEL = 'Field1'
+const SERVICE_ID = 'service-1'
+
+let serviceOrdinal = 0
+const serviceFactory = (label: string, serviceId?: string): Service =>
+	new Service({
+		id: serviceId ?? `service-${++serviceOrdinal}`,
+		label,
+		created: Date.now(),
+		modified: Date.now(),
+		content: {},
+	})
+
+const formFactory = async (parentId: string, anchorId: string, formTemplateId: string, label: string): Promise<ICureForm> =>
+	new ICureForm({ id: `new-form-${Date.now()}`, formTemplateId, descr: label, parent: parentId })
+
+const formRecycler = async (): Promise<void> => {
+	// no-op
+}
+
+const makeForm = (): ICureForm => new ICureForm({ id: FORM_ID, formTemplateId: FORM_TEMPLATE_ID, descr: 'Form' })
+
+const filledService = (createdAt: number): Service => new Service({ id: SERVICE_ID, label: FIELD_LABEL, created: createdAt, modified: createdAt, content: { en: { stringValue: 'value' } } })
+
+const buildContainer = (currentContact: Contact, history: Contact[]): ContactFormValuesContainer =>
+	new ContactFormValuesContainer(makeForm(), currentContact, history, serviceFactory, [], formFactory, formRecycler, [], undefined, true)
+
+const emptyField = (container: ContactFormValuesContainer): ContactFormValuesContainer => {
+	let updated: ContactFormValuesContainer | undefined
+	container.registerChangeListener((newValue) => {
+		updated = newValue as ContactFormValuesContainer
+	})
+	// An empty content for the language clears the field.
+	container.setValue(FIELD_LABEL, 'en', new Service({ id: SERVICE_ID, content: {} }), SERVICE_ID)
+	expect(updated).toBeDefined()
+	return updated!
+}
+
+describe('setValue — emptying a field', () => {
+	it('removes a service that exists only in the current contact', () => {
+		const now = Date.now()
+		const currentContact = new Contact({
+			id: 'contact-current',
+			created: now,
+			services: [filledService(now)],
+			subContacts: [{ formId: FORM_ID, services: [{ serviceId: SERVICE_ID }] }],
+		})
+
+		const container = buildContainer(currentContact, [])
+		const updated = emptyField(container)
+
+		const coordinated = updated.coordinatedContact()
+		expect(coordinated.services?.find((s) => s.id === SERVICE_ID)).toBeUndefined()
+	})
+
+	it('keeps a service that also exists in history, marking it with endOfLife', () => {
+		const past = Date.now() - 10000
+		const historyContact = new Contact({
+			id: 'contact-1',
+			rev: '1-abc',
+			created: past,
+			services: [filledService(past)],
+			subContacts: [{ formId: FORM_ID, services: [{ serviceId: SERVICE_ID }] }],
+		})
+		const currentContact = new Contact({
+			id: 'contact-2',
+			rev: '2-def',
+			created: past + 5000,
+			services: [filledService(past + 5000)],
+			subContacts: [{ formId: FORM_ID, services: [{ serviceId: SERVICE_ID }] }],
+		})
+
+		const container = buildContainer(currentContact, [historyContact])
+		const updated = emptyField(container)
+
+		const coordinated = updated.coordinatedContact()
+		const svc = coordinated.services?.find((s) => s.id === SERVICE_ID)
+		expect(svc).toBeDefined()
+		expect(svc?.endOfLife).toBeGreaterThan(0)
+
+		// And it must not be displayed anymore.
+		const values = updated.getValues((id, history) => history.map((h) => h.revision))
+		expect(values[SERVICE_ID]).toBeUndefined()
+	})
+
+	it('adds an endOfLife tombstone when the service exists only in history (not yet in the current contact)', () => {
+		const past = Date.now() - 10000
+		const historyContact = new Contact({
+			id: 'contact-1',
+			rev: '1-abc',
+			created: past,
+			services: [filledService(past)],
+			subContacts: [{ formId: FORM_ID, services: [{ serviceId: SERVICE_ID }] }],
+		})
+		const currentContact = new Contact({
+			id: 'contact-2',
+			rev: '2-def',
+			created: past + 5000,
+			services: [],
+			subContacts: [],
+		})
+
+		const container = buildContainer(currentContact, [historyContact])
+		const updated = emptyField(container)
+
+		const coordinated = updated.coordinatedContact()
+		const svc = coordinated.services?.find((s) => s.id === SERVICE_ID)
+		expect(svc).toBeDefined()
+		expect(svc?.endOfLife).toBeGreaterThan(0)
+
+		const values = updated.getValues((id, history) => history.map((h) => h.revision))
+		expect(values[SERVICE_ID]).toBeUndefined()
+	})
+})


### PR DESCRIPTION
When a field is emptied, setValue removed the service from the current contact entirely. That is correct for services that live only in the current contact, but a service also held by a history contact (and linked to this form via a subContact) is re-indexed from history on reload, so the emptied value reappeared.

Now the no-content branch scans the history contacts explicitly: if the service exists in history it is kept with an endOfLife tombstone (same strategy as removeChild), otherwise it is dropped as before.